### PR TITLE
chore: add Component type to angular.json

### DIFF
--- a/packages/frontend/angular.json
+++ b/packages/frontend/angular.json
@@ -11,7 +11,8 @@
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
-          "style": "scss"
+          "style": "scss",
+          "type": "Component"
         }
       },
       "root": "",


### PR DESCRIPTION
### ⚡ **PR: chore: add Component type to angular.json**

---

#### 📋 **Description**

- **What:** Added `"type": "Component"` to the `@schematics/angular:component `options in `angular.json`.
- **Why:** To ensure consistent component class naming and file structure when generating components via the Angular CLI.
- **Related Issue:** [#23]

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [x] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Run `ng g c test-component` inside the frontend workspace.
2. **Expected result:** The CLI automatically creates the class and files with the correct `Component` suffix (e.g., `test-component.component.ts` and `TestComponentComponent`).

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable) - N/A
- [ ] Documentation updated (if needed) - N/A

---

#### 📸 **Screenshots / GIFs**
<img width="291" height="459" alt="1" src="https://github.com/user-attachments/assets/2244546e-0d19-4190-b13c-7f62df6da2f6" />
<img width="742" height="348" alt="2" src="https://github.com/user-attachments/assets/888b3f3a-860d-473f-b292-5ddfebd9ee53" />
