### PR TITLE
feat: add image component

### DIFF
--- a/packages/frontend/angular.json
+++ b/packages/frontend/angular.json
@@ -37,6 +37,11 @@
                 "glob": "**/*",
                 "input": "src/assets/icons",
                 "output": "@/assets/icons"
+              },
+              {
+                "glob": "**/*",
+                "input": "src/assets/images",
+                "output": "@/assets/images"
               }
             ],
             "styles": ["src/assets/styles/index.scss"],

--- a/packages/frontend/src/shared/ui/image/image.component.html
+++ b/packages/frontend/src/shared/ui/image/image.component.html
@@ -1,0 +1,9 @@
+<img
+  class="image"
+  [src]="src()"
+  [alt]="alt()"
+  [attr.width]="width() || null"
+  [attr.height]="height() || null"
+  [attr.loading]="loading() || null"
+  [attr.fetchPriority]="fetchPriority() || null"
+/>

--- a/packages/frontend/src/shared/ui/image/image.component.scss
+++ b/packages/frontend/src/shared/ui/image/image.component.scss
@@ -1,0 +1,12 @@
+.image {
+  display: block;
+
+  width: 100%;
+  height: 100%;
+
+  // TODO: use variables
+  color: #f2f2f2;
+
+  object-fit: cover;
+  background-color: #222;
+}

--- a/packages/frontend/src/shared/ui/image/image.component.spec.ts
+++ b/packages/frontend/src/shared/ui/image/image.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ImageComponent } from './image.component';
+
+describe('ImageComponent', () => {
+  let component: ImageComponent;
+  let fixture: ComponentFixture<ImageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ImageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImageComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/shared/ui/image/image.component.ts
+++ b/packages/frontend/src/shared/ui/image/image.component.ts
@@ -1,0 +1,18 @@
+import { Component, input } from '@angular/core';
+
+import type { Loading, FetchPriority } from './image.types';
+
+@Component({
+  selector: 'app-image',
+  imports: [],
+  templateUrl: './image.component.html',
+  styleUrl: './image.component.scss',
+})
+export class ImageComponent {
+  src = input.required<string>();
+  alt = input<string | undefined>(' ');
+  width = input<string | undefined>();
+  height = input<string | undefined>();
+  loading = input<Loading | undefined>();
+  fetchPriority = input<FetchPriority | undefined>();
+}

--- a/packages/frontend/src/shared/ui/image/image.types.ts
+++ b/packages/frontend/src/shared/ui/image/image.types.ts
@@ -1,0 +1,4 @@
+type Loading = 'eager' | 'lazy';
+type FetchPriority = 'high' | 'low' | 'auto';
+
+export type { Loading, FetchPriority };

--- a/packages/frontend/src/shared/ui/index.ts
+++ b/packages/frontend/src/shared/ui/index.ts
@@ -1,1 +1,2 @@
 export { IconComponent } from './icon/icon.component';
+export { ImageComponent } from './image/image.component';


### PR DESCRIPTION
### ⚡ **PR: Add image component**

---

#### 📋 **Description**

- **What:** Add image component
- **Why:** Stop have layout shift if img is not loaded
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2?pane=issue&itemId=159095480&issue=rolling-scopes-school%7Celrouss-JSFE2025Q3%7C27

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. [Step 1] Add img component
2. **Expected result:** It appears

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`

---

#### 📸 **Screenshots / GIFs**
<img width="807" height="459" alt="Screenshot 2026-02-22 at 22 23 42" src="https://github.com/user-attachments/assets/e8b5e717-ea83-4b11-a627-b0a2a68a6b91" />
<img width="634" height="377" alt="Screenshot 2026-02-22 at 22 24 12" src="https://github.com/user-attachments/assets/c39daac4-a5d0-4645-9ddc-6df31f5716ac" />
