### PR TITLE
feat: create ui component - Badge

### DIFF
--- a/packages/frontend/src/features/quiz/ui/badge/badge.component.html
+++ b/packages/frontend/src/features/quiz/ui/badge/badge.component.html
@@ -1,0 +1,5 @@
+@let l = level();
+
+<span class="badge badge_{{ l }}">
+  {{ l | titlecase }}
+</span>

--- a/packages/frontend/src/features/quiz/ui/badge/badge.component.scss
+++ b/packages/frontend/src/features/quiz/ui/badge/badge.component.scss
@@ -1,0 +1,27 @@
+@use 'assets/styles/placeholders';
+
+:host {
+  @extend %host-base;
+}
+
+.badge {
+  padding: var(--spacing-x1) var(--spacing-x2);
+  border-radius: var(--radius-sm);
+
+  // TODO: think on color variables
+  &_senior {
+    background-color: gold;
+  }
+
+  &_middle {
+    background-color: silver;
+  }
+
+  &_junior {
+    background-color: lightcoral;
+  }
+
+  &_trainee {
+    background-color: pink;
+  }
+}

--- a/packages/frontend/src/features/quiz/ui/badge/badge.component.spec.ts
+++ b/packages/frontend/src/features/quiz/ui/badge/badge.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BadgeComponent } from './badge.component';
+
+import { computeRewardLevel } from './badge.utilities';
+import { REWARD_LEVEL, REWARD_SCORE } from './badge.constants';
+
+describe('BadgeComponent', () => {
+  let component: BadgeComponent;
+  let fixture: ComponentFixture<BadgeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BadgeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BadgeComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('score', 0);
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+
+describe('computeRewardLevel', () => {
+  it.each([
+    { score: REWARD_SCORE[REWARD_LEVEL.senior], expected: REWARD_LEVEL.senior },
+    { score: REWARD_SCORE[REWARD_LEVEL.senior] - 1, expected: REWARD_LEVEL.middle },
+
+    { score: REWARD_SCORE[REWARD_LEVEL.middle], expected: REWARD_LEVEL.middle },
+    { score: REWARD_SCORE[REWARD_LEVEL.middle] - 1, expected: REWARD_LEVEL.junior },
+
+    { score: REWARD_SCORE[REWARD_LEVEL.junior], expected: REWARD_LEVEL.junior },
+    { score: REWARD_SCORE[REWARD_LEVEL.junior] - 1, expected: REWARD_LEVEL.trainee },
+
+    { score: 0, expected: REWARD_LEVEL.trainee },
+  ])('score=$score -> $expected', ({ score, expected }) => {
+    expect(computeRewardLevel(score)).toBe(expected);
+  });
+});

--- a/packages/frontend/src/features/quiz/ui/badge/badge.component.ts
+++ b/packages/frontend/src/features/quiz/ui/badge/badge.component.ts
@@ -1,0 +1,16 @@
+import { Component, input, computed } from '@angular/core';
+import { TitleCasePipe } from '@angular/common';
+
+import { computeRewardLevel } from './badge.utilities';
+
+@Component({
+  selector: 'app-badge',
+  imports: [TitleCasePipe],
+  templateUrl: './badge.component.html',
+  styleUrl: './badge.component.scss',
+  standalone: true,
+})
+export class BadgeComponent {
+  readonly score = input.required<number>();
+  readonly level = computed(() => computeRewardLevel(this.score()));
+}

--- a/packages/frontend/src/features/quiz/ui/badge/badge.constants.ts
+++ b/packages/frontend/src/features/quiz/ui/badge/badge.constants.ts
@@ -1,0 +1,12 @@
+export const REWARD_LEVEL = {
+  senior: 'senior',
+  middle: 'middle',
+  junior: 'junior',
+  trainee: 'trainee',
+} as const;
+
+export const REWARD_SCORE = {
+  [REWARD_LEVEL.senior]: 90,
+  [REWARD_LEVEL.middle]: 70,
+  [REWARD_LEVEL.junior]: 50,
+} as const;

--- a/packages/frontend/src/features/quiz/ui/badge/badge.utilities.ts
+++ b/packages/frontend/src/features/quiz/ui/badge/badge.utilities.ts
@@ -1,0 +1,17 @@
+import { REWARD_LEVEL, REWARD_SCORE } from './badge.constants';
+
+export const computeRewardLevel = (score: number) => {
+  if (score >= REWARD_SCORE[REWARD_LEVEL.senior]) {
+    return REWARD_LEVEL.senior;
+  }
+
+  if (score >= REWARD_SCORE[REWARD_LEVEL.middle]) {
+    return REWARD_LEVEL.middle;
+  }
+
+  if (score >= REWARD_SCORE[REWARD_LEVEL.junior]) {
+    return REWARD_LEVEL.junior;
+  }
+
+  return REWARD_LEVEL.trainee;
+};

--- a/packages/frontend/src/features/quiz/ui/index.ts
+++ b/packages/frontend/src/features/quiz/ui/index.ts
@@ -1,0 +1,1 @@
+export { BadgeComponent } from './badge/badge.component';


### PR DESCRIPTION
### ⚡ **PR: Quiz UI Badge component + reward level utility**

---

#### 📋 **Description**

- **What:** Added a reusable quiz `BadgeComponent` to display a reward level based on score. Introduced `computeRewardLevel` utility and centralized reward thresholds/constants. Exported the component via the quiz UI barrel and added a small demo usage in `AppComponent`.
- **Why:** Provide a consistent, reusable UI primitive for showing quiz progress/reward tier, with isolated and testable score-to-level logic.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2/views/1?pane=issue&itemId=161135109&issue=rolling-scopes-school%7Celrouss-JSFE2025Q3%7C31

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Run `npm run test -w @rs-tandem/frontend`
2. Run `npm run start:frontend`
3. **Expected result:** Badge renders the correct level label and applies the corresponding `badge_<level>` class for different `score` values. Unit tests pass without `NG0950` (required input is provided in tests).

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**

<img width="354" height="45" alt="Screenshot 2026-03-07 at 13 37 38" src="https://github.com/user-attachments/assets/be3e2762-c372-418b-8242-b6d1e82f6698" />
