### PR TITLE
fix: Categories progress ignores in-progress re-attempts

### DIFF
--- a/packages/backend/src/quiz/quiz.repository.ts
+++ b/packages/backend/src/quiz/quiz.repository.ts
@@ -183,15 +183,15 @@ export class QuizRepository {
          COUNT(CASE WHEN latest.completed_at IS NOT NULL THEN 1 END)::INT AS topics_complete_count,
          CASE
            WHEN COUNT(qt.id) = 0 THEN 0
-           ELSE COUNT(CASE WHEN latest.completed_at IS NOT NULL THEN 1 END)::FLOAT / COUNT(qt.id)
+           ELSE ROUND(COUNT(CASE WHEN latest.completed_at IS NOT NULL THEN 1 END)::FLOAT / COUNT(qt.id) * 100)::INT
          END AS progress
        FROM quiz_categories qc
        LEFT JOIN quiz_topics qt ON qt.category_id = qc.id
        LEFT JOIN LATERAL (
          SELECT completed_at
          FROM user_quiz_attempts
-         WHERE user_id = $1 AND topic_id = qt.id
-         ORDER BY created_at DESC
+         WHERE user_id = $1 AND topic_id = qt.id AND completed_at IS NOT NULL
+         ORDER BY completed_at DESC
          LIMIT 1
        ) latest ON true
        GROUP BY qc.id, qc.name_en, qc.name_ru, qc.description_en, qc.description_ru
@@ -269,7 +269,7 @@ export class QuizRepository {
     const topics = topicsResult.rows.map((row) => toTopicSummary(row));
     const topicsCount = topics.length;
     const topicsCompleteCount = topics.filter((topic) => topic.score !== null).length;
-    const progress = topicsCount === 0 ? 0 : topicsCompleteCount / topicsCount;
+    const progress = topicsCount === 0 ? 0 : Math.round((topicsCompleteCount / topicsCount) * 100);
 
     return {
       id: catRow.id,


### PR DESCRIPTION
### ⚡ **PR: fix: Categories progress ignores in-progress re-attempts**

---

#### 📋 **Description**

- **What:** Fixed category progress calculation to only consider completed attempts when determining topic completion status, and normalized progress to a 0–100 integer percentage.
- **Why:** When a user re-attempted a topic (starting a new attempt while having a previous completion), the LATERAL join was picking up the latest attempt regardless of completion status. This caused a topic to appear "in progress" instead of "complete", incorrectly lowering the category progress. Additionally, the progress value was returned as a raw ratio instead of a percentage integer.
- **Related Issue:** N/A

---

## 📦 Affected Packages

- [ ] `@rs-tandem/frontend`
- [x] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Complete a quiz topic so it shows as done in category progress.
2. Start re-attempting the same topic (begin but do not finish).
3. Navigate to the categories list.
4. **Expected result:** The category progress should still reflect the topic as completed, not reset/lower due to the in-progress re-attempt.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**

N/A