### PR TITLE
feat: add library page

### DIFF
--- a/packages/frontend/src/app/app.routes.ts
+++ b/packages/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { HomeComponent } from '@/pages/home/home.component';
 import { Routes } from '@angular/router';
 import { SignInComponent } from '@/pages/sign-in/sign-in.component';
 import { SignUpComponent } from '@/pages/sign-up/sign-up.component';
+import { LibraryComponent } from '@/pages/library';
 
 import {
   CategoriesPageComponent,
@@ -16,6 +17,7 @@ export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'sign-in', component: SignInComponent },
   { path: 'sign-up', component: SignUpComponent },
+  { path: 'library', component: LibraryComponent },
   {
     path: 'quiz',
     data: { breadcrumb: 'Quiz' },

--- a/packages/frontend/src/core/services/navigation.service.ts
+++ b/packages/frontend/src/core/services/navigation.service.ts
@@ -11,9 +11,9 @@ export class NavService {
   ];
 
   private readonly authLinks: NavLink[] = [
+    { label: 'Profile', path: '/profile', isAnchor: false },
     { label: 'Library', path: '/library', isAnchor: false },
     { label: 'Dashboard', path: '/dashboard', isAnchor: false },
-    { label: 'Profile', path: '/profile', isAnchor: false },
   ];
 
   links = signal<NavLink[]>(this.guestLinks);

--- a/packages/frontend/src/pages/library/index.ts
+++ b/packages/frontend/src/pages/library/index.ts
@@ -1,0 +1,1 @@
+export { LibraryComponent } from './library.component';

--- a/packages/frontend/src/pages/library/library.component.html
+++ b/packages/frontend/src/pages/library/library.component.html
@@ -1,0 +1,21 @@
+<section class="library">
+  <h1 class="h2">Library</h1>
+
+  <ul class="library__list">
+    @for (feature of features; track $index) {
+      <li class="library__list-item">
+        <app-card [title]="feature.heading" footerPosition="end"
+          >{{ feature.description }}
+          <app-button
+            icon="arrow-up"
+            iconPosition="end"
+            [link]="feature.href"
+            [isSmallButton]="true"
+            appCardFooter
+            >Explore</app-button
+          >
+        </app-card>
+      </li>
+    }
+  </ul>
+</section>

--- a/packages/frontend/src/pages/library/library.component.scss
+++ b/packages/frontend/src/pages/library/library.component.scss
@@ -1,0 +1,20 @@
+@use 'assets/styles/mixins' as mix;
+
+.library {
+  margin-block-start: var(--spacing-x13);
+
+  &__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 28px;
+    margin-block-start: var(--spacing-x10);
+  }
+
+  &__list-item {
+    max-width: 458px;
+
+    @include mix.media('s') {
+      max-width: 100%;
+    }
+  }
+}

--- a/packages/frontend/src/pages/library/library.component.spec.ts
+++ b/packages/frontend/src/pages/library/library.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { LibraryComponent } from './library.component';
+
+describe('LibraryComponent', () => {
+  let component: LibraryComponent;
+  let fixture: ComponentFixture<LibraryComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LibraryComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LibraryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/pages/library/library.component.ts
+++ b/packages/frontend/src/pages/library/library.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+import { ButtonComponent, CardComponent, CardFooterDirective } from '@/shared/ui';
+
+import { features } from './library.constants';
+
+@Component({
+  selector: 'app-library',
+  imports: [ButtonComponent, CardComponent, CardFooterDirective],
+  templateUrl: './library.component.html',
+  styleUrl: './library.component.scss',
+})
+export class LibraryComponent {
+  readonly features = features;
+}

--- a/packages/frontend/src/pages/library/library.constants.ts
+++ b/packages/frontend/src/pages/library/library.constants.ts
@@ -1,0 +1,14 @@
+export const features = [
+  {
+    heading: 'AI',
+    description:
+      'Practice JS/TS with an AI tutor right inside the platform.\nAsk questions, request explanations, or get hints for tricky topics.\nThe chat streams responses and keeps the dialogue context.\nPerfect for quick clarifications, interview prep, and focused learning sessions',
+    href: '/ai-chat',
+  },
+  {
+    heading: 'Quiz',
+    description:
+      'Pick a category and topic, then answer programming questions fast.\nYou have 2 minutes — a quick interview warm-up.\nAfter the round you get your score, feedback, and links to reinforce learning and go deeper.\nEarn badges and track your progress over time',
+    href: '/quiz',
+  },
+] as const;

--- a/packages/frontend/src/shared/ui/index.ts
+++ b/packages/frontend/src/shared/ui/index.ts
@@ -1,6 +1,7 @@
 export { BreadcrumbComponent } from './breadcrumb';
 export { ButtonComponent } from './button/button.component';
 export { CardComponent } from './card/card.component';
+export { CardFooterDirective } from './card/card-footer.directive';
 export { IconButtonComponent } from './icon-button/icon-button.component';
 export { IconComponent } from './icon/icon.component';
 export { LogoComponent } from './logo/logo.component';


### PR DESCRIPTION
### ⚡ **PR: Library page + Card footer slot**

---

#### 📋 **Description**

- **What:** Added a new `Library` page that lists available learning modules (AI Chat + Quiz) as cards with an “Explore” button in the card footer. Wired up routing and navigation, and exposed a reusable card footer projection API via `appCardFooter`.
- **Why:** Provide a single entry point to platform modules and make `app-card` extensible (footer actions) without coupling it to specific buttons/links.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2/views/1?pane=issue&itemId=165092725&issue=jsgods-rs-tandem%7Crs-tandem%7C108

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Run frontend: `npm run start:frontend`
2. Open `/library`
3. Click **Explore** on:
   - **AI** → should navigate to `/ai-chat`
   - **Quiz** → should navigate to `/quiz`
4. **Expected result:** Library renders 2 cards (AI, Quiz) with descriptions and a footer action button aligned to the end.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
<img width="1125" height="860" alt="Screenshot 2026-03-14 at 23 07 58" src="https://github.com/user-attachments/assets/6e624047-2d6a-45fc-873d-1e3f0f28de9c" />
<img width="578" height="855" alt="Screenshot 2026-03-14 at 23 08 07" src="https://github.com/user-attachments/assets/b25f9f90-c03e-48f1-a43b-f2307a0e8f24" />
<img width="350" height="857" alt="Screenshot 2026-03-14 at 23 08 18" src="https://github.com/user-attachments/assets/b281ea49-33bc-499c-911d-072c07f9cd9a" />