### PR TITLE
fix: highlight code snippet on each render

### DIFF
--- a/packages/frontend/src/features/quiz/ui/answer-tile-group/components/code-snippet/code-snippet.component.html
+++ b/packages/frontend/src/features/quiz/ui/answer-tile-group/components/code-snippet/code-snippet.component.html
@@ -1,1 +1,3 @@
-<pre class="code-snippet"><code class="language-javascript">{{ code() }}</code></pre>
+<pre
+  class="code-snippet"
+><code #codeEl class="language-javascript" [textContent]="code()"></code></pre>

--- a/packages/frontend/src/features/quiz/ui/answer-tile-group/components/code-snippet/code-snippet.component.ts
+++ b/packages/frontend/src/features/quiz/ui/answer-tile-group/components/code-snippet/code-snippet.component.ts
@@ -1,5 +1,14 @@
-import { AfterViewInit, Component, input } from '@angular/core';
-import { highlightAll } from 'prismjs';
+import {
+  Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  effect,
+  inject,
+  input,
+  viewChild,
+} from '@angular/core';
+import { highlightElement } from 'prismjs';
 
 import 'prismjs/components/prism-javascript';
 
@@ -10,10 +19,39 @@ import 'prismjs/components/prism-javascript';
   styleUrl: './code-snippet.component.scss',
   standalone: true,
 })
-export class CodeSnippetComponent implements AfterViewInit {
+export class CodeSnippetComponent {
   readonly code = input.required<string>();
 
-  ngAfterViewInit() {
-    highlightAll();
+  private readonly injector = inject(Injector);
+
+  private readonly codeEl = viewChild.required<ElementRef<HTMLElement>>('codeEl');
+
+  private lastHighlightedCode?: string;
+
+  constructor() {
+    effect(
+      () => {
+        const currentCode = this.code();
+        if (!currentCode || currentCode === this.lastHighlightedCode) {
+          return;
+        }
+
+        afterNextRender(
+          () => {
+            const latestCode = this.code();
+            if (!latestCode || latestCode === this.lastHighlightedCode) {
+              return;
+            }
+
+            const element = this.codeEl().nativeElement;
+            element.textContent = latestCode;
+            highlightElement(element);
+            this.lastHighlightedCode = latestCode;
+          },
+          { injector: this.injector },
+        );
+      },
+      { injector: this.injector },
+    );
   }
 }


### PR DESCRIPTION
### ⚡ **PR: Fix Prism highlighting on initial snippet render**

---

#### 📋 **Description**

- **What:** Updated `CodeSnippetComponent` to reliably apply Prism syntax highlighting on the initial page load by highlighting after the DOM is rendered, and re-highlighting only when the `code` input changes. Switched snippet rendering to `[textContent]` to avoid interpolation timing/HTML parsing issues.
- **Why:** When opening the quiz directly on a step containing a code snippet, Prism was triggered before the snippet content existed in the DOM, so highlighting did not apply. Navigating between steps worked because the DOM update sequence differed.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2/views/1?pane=issue&itemId=165607090&issue=jsgods-rs-tandem%7Crs-tandem%7C123

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Open the quiz directly on a step that contains a code snippet (fresh load / hard refresh).
2. Navigate between quiz steps (including ones with code snippets).
3. **Expected result:** Code snippets are syntax-highlighted on the initial load and remain correctly highlighted when moving between steps.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
N/A