### PR TITLE
feat: make breadcrumbs adaptive with scrollbar and add dynamic naming…

### DIFF
--- a/packages/frontend/src/assets/styles/index.scss
+++ b/packages/frontend/src/assets/styles/index.scss
@@ -33,6 +33,7 @@
   --spacing-x8: calc(var(--spacing-module) * 8);
   --spacing-x9: calc(var(--spacing-module) * 9);
   --spacing-x10: calc(var(--spacing-module) * 10);
+  --spacing-x11: calc(var(--spacing-module) * 11);
   --spacing-x13: calc(var(--spacing-module) * 13);
   --radius-xs: 2px;
   --radius-sm: 4px;

--- a/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.html
@@ -1,4 +1,6 @@
-<app-layout [loading]="quizService.loading().categories">
+@let loading = quizService.loading();
+
+<app-layout [loading]="loading.categories || loading.category">
   <header class="categories-page__header">
     <h1 class="h2">Quiz</h1>
   </header>

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.html
@@ -1,6 +1,7 @@
 @let category = quizService.category();
+@let loading = quizService.loading();
 
-<app-layout [loading]="quizService.loading().category">
+<app-layout [loading]="loading.category || loading.topic">
   @if (category) {
     <header class="category-page__header">
       <h1 class="h2">{{ category.name }}</h1>

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.ts
@@ -17,6 +17,10 @@ export class CategoryPageComponent implements OnInit {
   readonly categoryId = input.required<string>();
 
   ngOnInit(): void {
-    this.quizService.getCategory(this.categoryId());
+    const categoryId = this.categoryId();
+
+    if (this.quizService.category()?.id !== categoryId) {
+      this.quizService.getCategory(categoryId);
+    }
   }
 }

--- a/packages/frontend/src/features/quiz/pages/layout/layout.component.scss
+++ b/packages/frontend/src/features/quiz/pages/layout/layout.component.scss
@@ -6,7 +6,7 @@
 }
 
 .layout {
-  margin-block: var(--spacing-x13);
+  margin-block: var(--spacing-x11);
 
   &__section {
     display: flex;

--- a/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.html
@@ -3,7 +3,7 @@
 @let step = quizService.step();
 @let loading = quizService.loading();
 
-<app-layout [loading]="loading.topic">
+<app-layout [loading]="loading.topic || loading.results">
   @if (topic && question) {
     <header>
       <h1 class="h2">{{ topic.name }}</h1>

--- a/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.ts
@@ -82,7 +82,10 @@ export class QuizPageComponent implements OnInit {
   ngOnInit(): void {
     const topicId = this.topicId();
 
-    this.quizService.getTopic(topicId);
+    if (this.quizService.topic()?.id !== topicId) {
+      this.quizService.getTopic(topicId);
+    }
+
     this.quizService.startTopic(topicId);
   }
 

--- a/packages/frontend/src/features/quiz/resolvers/breadcrumb.resolvers.ts
+++ b/packages/frontend/src/features/quiz/resolvers/breadcrumb.resolvers.ts
@@ -1,19 +1,60 @@
+import { inject } from '@angular/core';
 import type { ResolveFn } from '@angular/router';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { distinctUntilChanged, filter, map, skipWhile, take } from 'rxjs';
 
-// Переделать после доработки бэка
-export const categoryBreadcrumbResolver: ResolveFn<string> = () => {
-  return 'Category';
+import { QuizService } from '../services';
 
-  // const categoryId = route.paramMap.get('categoryId');
-  // const name = categoryId ? categories.categories.find((c) => c.id === categoryId)?.name : '';
+export const categoryBreadcrumbResolver: ResolveFn<string> = (route) => {
+  const quizService = inject(QuizService);
+  const categoryId = route.paramMap.get('categoryId');
 
-  // return name ?? 'Category';
+  if (!categoryId) {
+    return 'Category';
+  }
+
+  quizService.getCategory(categoryId);
+
+  const loadingCategory$ = toObservable(quizService.loading).pipe(
+    map((loading) => loading.category),
+    distinctUntilChanged(),
+  );
+
+  return loadingCategory$.pipe(
+    skipWhile((isLoading) => !isLoading),
+    filter((isLoading) => !isLoading),
+    take(1),
+    map(() => {
+      const category = quizService.category();
+
+      return category?.id === categoryId ? category.name : 'Category';
+    }),
+  );
 };
 
-export const topicBreadcrumbResolver: ResolveFn<string> = () => {
-  return 'Topic';
-  // const topicId = route.paramMap.get('topicId');
-  // const name = topicId ? category.topics.find((t) => t.id === topicId)?.name : '';
+export const topicBreadcrumbResolver: ResolveFn<string> = (route) => {
+  const quizService = inject(QuizService);
+  const topicId = route.paramMap.get('topicId');
 
-  // return name ?? 'Topic';
+  if (!topicId) {
+    return 'Topic';
+  }
+
+  quizService.getTopic(topicId);
+
+  const loadingTopic$ = toObservable(quizService.loading).pipe(
+    map((loading) => loading.topic),
+    distinctUntilChanged(),
+  );
+
+  return loadingTopic$.pipe(
+    skipWhile((isLoading) => !isLoading),
+    filter((isLoading) => !isLoading),
+    take(1),
+    map(() => {
+      const topic = quizService.topic();
+
+      return topic?.id === topicId ? topic.name : 'Topic';
+    }),
+  );
 };

--- a/packages/frontend/src/features/quiz/services/quiz.service.ts
+++ b/packages/frontend/src/features/quiz/services/quiz.service.ts
@@ -148,6 +148,7 @@ export class QuizService {
   getCategory(id: string) {
     this._state.update((state) => ({
       ...state,
+      data: { ...state.data, category: null },
       loading: { ...state.loading, category: true },
       error: { ...state.error, category: '' },
     }));

--- a/packages/frontend/src/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/packages/frontend/src/shared/ui/breadcrumb/breadcrumb.component.html
@@ -2,7 +2,7 @@
 @let isSingleBreadcrumb = crumbs.length === 1;
 
 <!-- We hide breadcrumb if depth is only one level, preserving the location in the markup -->
-<nav [class.breadcrumb_hidden]="isSingleBreadcrumb" aria-label="Breadcrumb">
+<nav class="breadcrumb" [class.breadcrumb_hidden]="isSingleBreadcrumb" aria-label="Breadcrumb">
   <ol class="breadcrumb__list">
     @for (breadcrumb of crumbs; track breadcrumb.url; let last = $last) {
       <li class="breadcrumb__list-item">

--- a/packages/frontend/src/shared/ui/breadcrumb/breadcrumb.component.scss
+++ b/packages/frontend/src/shared/ui/breadcrumb/breadcrumb.component.scss
@@ -2,6 +2,11 @@
 @use 'assets/styles/mixins' as mix;
 
 .breadcrumb {
+  overflow: auto;
+  padding: var(--spacing-x2) var(--spacing-x1);
+  white-space: nowrap;
+  @include mix.set-scrollbar(6);
+
   &_hidden {
     @extend %hidden;
   }


### PR DESCRIPTION
### ⚡ **PR: Dynamic quiz breadcrumbs + adaptive breadcrumb UI**

---

#### 📋 **Description**

- **What:** Implemented dynamic breadcrumb labels for quiz category/topic routes via resolvers (fetching data by route params), improved breadcrumb UI to be horizontally scrollable (no wrapping), and adjusted quiz page loading states/layout spacing for smoother UX during data fetching.
- **Why:** Breadcrumb labels were static/`null` because routing ran before async data was available; the UI also needed better handling for long breadcrumb paths and consistent loader behavior while category/topic/results data loads.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2?pane=issue&itemId=165092453&issue=rolling-scopes-school%7Celrouss-JSFE2025Q3%7C41

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Open **Quiz → Categories** and ensure the page loader appears while categories/category are loading.
2. Click a category and verify breadcrumbs show the **actual category name** (not a placeholder) after loading.
3. Open a topic/quiz page and verify breadcrumbs show the **actual topic name**; trigger results loading and ensure the loader covers topic/results loading states.
4. Make the breadcrumb path long (deep navigation / narrow viewport) and verify breadcrumbs **do not wrap** and can be **horizontally scrolled**.
5. **Expected result:** Breadcrumbs display dynamic category/topic names, breadcrumb bar scrolls on overflow, and loaders behave consistently during async quiz requests.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
<img width="723" height="533" alt="Screenshot 2026-03-16 at 01 48 10" src="https://github.com/user-attachments/assets/2a4cb7cc-1053-41a5-84de-ec60d4b9d292" />
<img width="720" height="536" alt="Screenshot 2026-03-16 at 01 48 21" src="https://github.com/user-attachments/assets/192ff58a-62a9-4734-8b2c-24519436752f" />
<img width="725" height="534" alt="Screenshot 2026-03-16 at 01 48 48" src="https://github.com/user-attachments/assets/1d22b413-46d1-470c-8a31-50c18e63678d" />
<img width="345" height="770" alt="Screenshot 2026-03-16 at 20 10 43" src="https://github.com/user-attachments/assets/f3bfb884-e79e-4300-a1f4-814e4c34b806" />
<img width="232" height="769" alt="Screenshot 2026-03-16 at 01 49 09" src="https://github.com/user-attachments/assets/ead0d41c-8177-4b51-a2ef-b07a06898ce2" />
