### PR TITLE
feat: implement spint, breadcrumb and auth-guards unit tests

### DIFF
--- a/packages/frontend/src/core/guards/auth-guard/auth-guard.spec.ts
+++ b/packages/frontend/src/core/guards/auth-guard/auth-guard.spec.ts
@@ -1,17 +1,54 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
 
 import { authGuard } from './auth-guard';
 
-describe('authGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) =>
-    TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+import { HomeComponent } from '@/pages/home/home.component';
+import { LibraryComponent } from '@/pages/library/library.component';
+import { SignInComponent } from '@/pages/sign-in/sign-in.component';
+import { ScrollSpyService } from '@/shared/services/scroll-spy.service';
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
+import { ROUTES, ROUTE_PATHS } from '@/core/constants';
+
+describe('authGuard', () => {
+  beforeEach(async () => {
+    localStorage.clear();
+
+    const scrollSpyServiceStub: Pick<ScrollSpyService, 'spy' | 'cleanup'> = {
+      spy: () => undefined,
+      cleanup: () => undefined,
+    };
+
+    await TestBed.configureTestingModule({
+      providers: [
+        { provide: ScrollSpyService, useValue: scrollSpyServiceStub },
+        provideRouter([
+          { path: ROUTES.home, component: HomeComponent, canActivate: [authGuard] },
+          { path: ROUTES.library, component: LibraryComponent, canActivate: [authGuard] },
+          { path: ROUTES.signIn, component: SignInComponent, canActivate: [authGuard] },
+        ]),
+      ],
+    }).compileComponents();
   });
 
-  it('should be created', () => {
-    expect(executeGuard).toBeTruthy();
+  it('should redirect authenticated user from sign-in to library', async () => {
+    localStorage.setItem('auth_token', 'token');
+
+    const router = TestBed.inject(Router);
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl(ROUTE_PATHS.signIn);
+
+    expect(router.url).toBe(ROUTE_PATHS.library);
+  });
+
+  it('should redirect unauthenticated user from library to home', async () => {
+    const router = TestBed.inject(Router);
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl(ROUTE_PATHS.library);
+
+    expect(router.url).toBe(ROUTE_PATHS.home);
   });
 });

--- a/packages/frontend/src/shared/services/breadcrumb/breadcrumb.service.spec.ts
+++ b/packages/frontend/src/shared/services/breadcrumb/breadcrumb.service.spec.ts
@@ -1,20 +1,49 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
 
 import { BreadcrumbService } from './breadcrumb.service';
+
+import { SpinComponent } from '@/shared/ui/spin';
 
 describe('BreadcrumbService', () => {
   let service: BreadcrumbService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideRouter([])],
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          {
+            path: 'quiz',
+            component: SpinComponent,
+            data: { breadcrumb: 'Quiz' },
+            children: [
+              {
+                path: 'topic/:topicId',
+                component: SpinComponent,
+                data: { breadcrumb: 'Topic' },
+              },
+            ],
+          },
+        ]),
+      ],
+    }).compileComponents();
 
     service = TestBed.inject(BreadcrumbService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should build breadcrumbs on NavigationEnd', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/quiz/topic/123');
+
+    expect(service.breadcrumbs()).toEqual([
+      { label: 'Quiz', url: '/quiz' },
+      { label: 'Topic', url: '/quiz/topic/123' },
+    ]);
   });
 });

--- a/packages/frontend/src/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/packages/frontend/src/shared/ui/breadcrumb/breadcrumb.component.html
@@ -2,7 +2,12 @@
 @let isSingleBreadcrumb = crumbs.length === 1;
 
 <!-- We hide breadcrumb if depth is only one level, preserving the location in the markup -->
-<nav class="breadcrumb" [class.breadcrumb_hidden]="isSingleBreadcrumb" aria-label="Breadcrumb">
+<nav
+  class="breadcrumb"
+  [class.breadcrumb_hidden]="isSingleBreadcrumb"
+  aria-label="Breadcrumb"
+  data-testid="breadcrumb-nav"
+>
   <ol class="breadcrumb__list">
     @for (breadcrumb of crumbs; track breadcrumb.url; let last = $last) {
       <li class="breadcrumb__list-item">

--- a/packages/frontend/src/shared/ui/breadcrumb/breadcrumb.component.spec.ts
+++ b/packages/frontend/src/shared/ui/breadcrumb/breadcrumb.component.spec.ts
@@ -1,16 +1,26 @@
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
 import { BreadcrumbComponent } from './breadcrumb.component';
+
+import { BreadcrumbService } from '@/shared/services';
 
 describe('BreadcrumbComponent', () => {
   let component: BreadcrumbComponent;
   let fixture: ComponentFixture<BreadcrumbComponent>;
 
   beforeEach(async () => {
+    const breadcrumbServiceStub: Pick<BreadcrumbService, 'breadcrumbs'> = {
+      breadcrumbs: signal([{ label: 'Only', url: '/only' }]),
+    };
+
     await TestBed.configureTestingModule({
       imports: [BreadcrumbComponent],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        { provide: BreadcrumbService, useValue: breadcrumbServiceStub },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BreadcrumbComponent);
@@ -20,5 +30,16 @@ describe('BreadcrumbComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should hide breadcrumb nav when only one crumb', () => {
+    fixture.detectChanges();
+
+    const nav = document.querySelector('[data-testid="breadcrumb-nav"]');
+    if (!(nav instanceof HTMLElement)) {
+      throw new Error('Breadcrumb nav element not found');
+    }
+
+    expect(nav.classList.contains('breadcrumb_hidden')).toBe(true);
   });
 });

--- a/packages/frontend/src/shared/ui/spin/spin.component.html
+++ b/packages/frontend/src/shared/ui/spin/spin.component.html
@@ -1,3 +1,3 @@
-<span class="spin spin_size_{{ size() }} spin_theme_{{ theme() }}" role="status">
-  <span class="spin__text">Loading</span>
+<span class="spin spin_size_{{ size() }} spin_theme_{{ theme() }}" role="status" data-testid="spin">
+  <span class="spin__text" data-testid="spin__text">Loading</span>
 </span>

--- a/packages/frontend/src/shared/ui/spin/spin.component.spec.ts
+++ b/packages/frontend/src/shared/ui/spin/spin.component.spec.ts
@@ -19,4 +19,26 @@ describe('SpinComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render default classes and update when inputs change', async () => {
+    fixture.detectChanges();
+
+    const element = document.querySelector('[data-testid="spin"]');
+    if (!(element instanceof HTMLSpanElement)) {
+      throw new Error('Spin root element not found');
+    }
+
+    expect(element.getAttribute('role')).toBe('status');
+    expect(element.classList.contains('spin_size_medium')).toBe(true);
+    expect(element.classList.contains('spin_theme_dark')).toBe(true);
+    expect(element.textContent).toContain('Loading');
+
+    fixture.componentRef.setInput('size', 'large');
+    fixture.componentRef.setInput('theme', 'light');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(element.classList.contains('spin_size_large')).toBe(true);
+    expect(element.classList.contains('spin_theme_light')).toBe(true);
+  });
 });


### PR DESCRIPTION
### ⚡ **PR: Add unit tests for auth guard, breadcrumb, and spinner**

---

#### 📋 **Description**

- **What:** Added and updated unit tests for `SpinComponent`, `BreadcrumbComponent`, `BreadcrumbService`, and `authGuard`; introduced stable `data-testid` selectors in `spin` and `breadcrumb` templates to make tests resilient
- **Why:** To satisfy the assignment requirement (5 unit tests) and improve test reliability/maintainability 
- **Related Issue:** N/A

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [x] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. In `packages/frontend`, ensure the required Node.js version is active (Angular CLI requires Node >= 20.19 or >= 22.12).
2. Run `npm test` (or `npm run test:ui:coverage`).
3. **Expected result:** Test suite passes; new/updated specs run successfully and ESLint does not report `no-unsafe-*` issues in the modified test files.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
N/A