### PR TITLE
fix: increase healthcheck timeout to 120s to survive re-seeding

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ dockerfilePath = "packages/backend/Dockerfile"
 
 [deploy]
 healthcheckPath = "/api/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 120
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
### ⚡ **PR: Fix deployment failure caused by health check timeout during re-seed**

---

#### 📋 **Description**

- **What:** Increased `healthcheckTimeout` in `railway.toml` from 30s to 120s.
- **Why:** Re-seeding ~4500 rows via `ON CONFLICT DO UPDATE` takes ~31s, which exceeds the previous 30s timeout. Railway was sending SIGTERM mid-seed, causing deployments to fail and revert to the previous version. Fresh INSERTs on an empty DB take only ~4.6s, so the issue only appeared on re-deployments (not the initial deploy).
- **Related Issue:** —

---

## 📦 Affected Packages

- [ ] `@rs-tandem/frontend`
- [x] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [x] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

> ⚠️ Cannot be tested locally — requires a Railway deployment to reproduce the health check timeout behaviour.

1. Trigger a new Railway deployment on `production` (or the `fix/backend/deploy-timeout` environment).
2. Watch `railway logs --service rs-tandem` — all 14 seed files should appear including `07-typescript.json`.
3. **Expected result:** "Nest application successfully started" appears without "Stopping Container" cutting it short. Health check passes within the 120s window.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**

_Deployment logs from `fix/backend/deploy-timeout` environment confirming the fix._