### PR TITLE
feat: add challenges card inside library

### DIFF
--- a/packages/frontend/src/core/constants/routes.ts
+++ b/packages/frontend/src/core/constants/routes.ts
@@ -5,6 +5,7 @@ export const ROUTES = {
   profile: 'profile',
   library: 'library',
   aiChat: 'ai-chat',
+  challenges: 'challenges',
   quiz: 'quiz',
   quizCategory: ':categoryId',
   quizTopic: 'topic/:topicId',
@@ -20,6 +21,7 @@ export const ROUTE_PATHS = {
   profile: `/${ROUTES.profile}`,
   library: `/${ROUTES.library}`,
   aiChat: `/${ROUTES.aiChat}`,
+  challenges: `/${ROUTES.challenges}`,
   quiz: `/${ROUTES.quiz}`,
   dashboard: `/${ROUTES.dashboard}`,
 } as const;

--- a/packages/frontend/src/pages/library/library.component.scss
+++ b/packages/frontend/src/pages/library/library.component.scss
@@ -7,7 +7,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 28px;
-    margin-block-start: var(--spacing-x10);
+    margin-block: var(--spacing-x10);
   }
 
   &__list-item {

--- a/packages/frontend/src/pages/library/library.constants.ts
+++ b/packages/frontend/src/pages/library/library.constants.ts
@@ -8,6 +8,12 @@ export const features = [
     href: ROUTE_PATHS.aiChat,
   },
   {
+    heading: 'Challenges',
+    description:
+      "Solve interactive JS and algorithmic tasks from top-tier tech interviews. Master the specific logic and data structures you'll face in real-world technical screenings. Write code, run tests, and track your progress as you bridge the gap between basic coding and high-level engineering",
+    href: ROUTE_PATHS.challenges,
+  },
+  {
     heading: 'Quiz',
     description:
       'Pick a category and topic, then answer programming questions fast.\nYou have 2 minutes — a quick interview warm-up.\nAfter the round you get your score, feedback, and links to reinforce learning and go deeper.\nEarn badges and track your progress over time',


### PR DESCRIPTION
### ⚡ **PR: Add “Challenges” card to Library**

---

#### 📋 **Description**

- **What:** Added a new **Challenges** feature card to the Library page, introduced `challenges` route constants (`ROUTES` / `ROUTE_PATHS`), and slightly adjusted Library list spacing (`margin-block`).
- **Why:** To expose the Challenges section from the Library as a first-class entry point and ensure navigation uses consistent route constants.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2/views/1?pane=issue&itemId=166099384&issue=jsgods-rs-tandem%7Crs-tandem%7C144

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Start the frontend app.
2. Navigate to the **Library** page.
3. **Expected result:** A new **Challenges** card is visible; clicking it navigates to `/challenges`.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
<img width="763" height="633" alt="Screenshot 2026-03-17 at 03 04 18" src="https://github.com/user-attachments/assets/68c28743-ed79-4064-8efe-fcaec1ee1095" />
<img width="645" height="858" alt="Screenshot 2026-03-17 at 03 04 29" src="https://github.com/user-attachments/assets/9116cb43-8b6f-4c94-bb6a-258aed2a101b" />
<img width="317" height="852" alt="Screenshot 2026-03-17 at 03 04 38" src="https://github.com/user-attachments/assets/5145cf99-6620-4954-a4fa-b21a052deb9d" />
