### PR TITLE
feat: add error handling in quiz

### DIFF
--- a/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.html
@@ -1,12 +1,28 @@
 @let loading = quizService.loading();
+@let categoriesValue = quizService.categories();
 
 <app-layout [loading]="loading.categories || loading.category">
-  <header class="categories-page__header">
-    <h1 class="h2">Quiz</h1>
-  </header>
+  @if (categoriesValue.length > 0) {
+    <header class="categories-page__header">
+      <h1 class="h2">Quiz</h1>
+    </header>
 
-  <app-category-card-list
-    class="categories-page__category-card-list"
-    [categories]="quizService.categories()"
-  />
+    <app-category-card-list
+      class="categories-page__category-card-list"
+      [categories]="quizService.categories()"
+    />
+  } @else {
+    <app-empty
+      class="categories-page__empty"
+      heading="No&nbsp;categories available"
+      [headingLevel]="1"
+      description="We&nbsp;couldn&rsquo;t find any quiz categories at&nbsp;the moment. Try refreshing the page to&nbsp;see if&nbsp;anything has changed"
+      ><app-button
+        class="categories-page__refresh-button"
+        [isSmallButton]="true"
+        (click)="quizService.reloadPage()"
+        >Refresh page</app-button
+      ></app-empty
+    >
+  }
 </app-layout>

--- a/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.scss
+++ b/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.scss
@@ -17,4 +17,12 @@
   &__category-card-list {
     margin-block-start: var(--spacing-x10);
   }
+
+  &__empty {
+    margin: auto;
+  }
+
+  &__refresh-button {
+    margin-block-start: var(--spacing-x4);
+  }
 }

--- a/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject, type OnInit } from '@angular/core';
 
+import { ButtonComponent, EmptyComponent } from '@/shared/ui';
 import { LayoutComponent } from '../layout';
 import { CategoryCardListComponent } from '../../ui';
 
@@ -7,7 +8,7 @@ import { QuizService } from '../../services';
 
 @Component({
   selector: 'app-categories-page',
-  imports: [CategoryCardListComponent, LayoutComponent],
+  imports: [ButtonComponent, CategoryCardListComponent, EmptyComponent, LayoutComponent],
   templateUrl: './categories-page.component.html',
   styleUrl: './categories-page.component.scss',
   standalone: true,

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.html
@@ -15,5 +15,20 @@
     </header>
 
     <app-topic-card-list class="category-page__topic-card-list" [topics]="category.topics" />
+  } @else {
+    <app-empty
+      class="category-page__empty"
+      heading="Category is&nbsp;currently empty"
+      [headingLevel]="1"
+      description="We&nbsp;couldn&rsquo;t find any quizzes in&nbsp;this category right now. Try refreshing the page or&nbsp;explore other categories"
+    >
+      <div class="category-page__nav-buttons">
+        <app-button [isSmallButton]="true" (click)="quizService.reloadPage()"
+          >Refresh page</app-button
+        >
+
+        <app-button link="/quiz" [isSmallButton]="true">Back to&nbsp;categories</app-button>
+      </div>
+    </app-empty>
   }
 </app-layout>

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.scss
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.scss
@@ -27,4 +27,18 @@
   &__topic-card-list {
     margin-block-start: var(--spacing-x10);
   }
+
+  &__empty {
+    margin: auto;
+  }
+
+  &__nav-buttons {
+    display: flex;
+    gap: var(--spacing-x4);
+    margin-block-start: var(--spacing-x4);
+
+    @include mix.media('s') {
+      flex-direction: column;
+    }
+  }
 }

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject, input, type OnInit } from '@angular/core';
 
+import { ButtonComponent, EmptyComponent } from '@/shared/ui';
 import { LayoutComponent } from '../layout';
 import { ProgressComponent, TopicCardListComponent } from '../../ui';
 
@@ -7,7 +8,13 @@ import { QuizService } from '../../services';
 
 @Component({
   selector: 'app-category-page',
-  imports: [LayoutComponent, ProgressComponent, TopicCardListComponent],
+  imports: [
+    ButtonComponent,
+    EmptyComponent,
+    LayoutComponent,
+    ProgressComponent,
+    TopicCardListComponent,
+  ],
   templateUrl: './category-page.component.html',
   styleUrl: './category-page.component.scss',
   standalone: true,

--- a/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.html
@@ -49,5 +49,20 @@
         >
       </form>
     </div>
+  } @else {
+    <app-empty
+      class="quiz-page__empty"
+      heading="Quiz content not found"
+      [headingLevel]="1"
+      description="We&rsquo;re having trouble loading the questions for this quiz. Try refreshing the page or&nbsp;see all categories to&nbsp;choose another topic"
+    >
+      <div class="quiz-page__nav-buttons">
+        <app-button [isSmallButton]="true" (click)="quizService.reloadPage()"
+          >Refresh page</app-button
+        >
+
+        <app-button link="/quiz" [isSmallButton]="true">Back to&nbsp;categories</app-button>
+      </div>
+    </app-empty>
   }
 </app-layout>

--- a/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.scss
+++ b/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.scss
@@ -52,4 +52,18 @@
   &__submit-button {
     margin: var(--spacing-x5) auto 0;
   }
+
+  &__empty {
+    margin: auto;
+  }
+
+  &__nav-buttons {
+    display: flex;
+    gap: var(--spacing-x4);
+    margin-block-start: var(--spacing-x4);
+
+    @include mix.media('s') {
+      flex-direction: column;
+    }
+  }
 }

--- a/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.ts
@@ -4,7 +4,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 
 import { ShufflePipe } from '@/shared/pipes';
 
-import { ButtonComponent } from '@/shared/ui';
+import { ButtonComponent, EmptyComponent } from '@/shared/ui';
 import { LayoutComponent } from '../layout';
 import {
   AnswerTileGroupComponent,
@@ -27,6 +27,7 @@ import { successAnswers, errorAnswers } from './quiz-page.constants';
     ButtonComponent,
     CountdownTimerComponent,
     DecimalPipe,
+    EmptyComponent,
     LayoutComponent,
     ReactiveFormsModule,
     ShufflePipe,
@@ -58,6 +59,8 @@ export class QuizPageComponent implements OnInit {
     this.isQuizComplete() ? ROUTES.quizResults : undefined,
   );
 
+  private readonly _isTimeExpired = signal(false);
+
   constructor() {
     effect(() => {
       const answer = this.quizService.answer();
@@ -65,6 +68,8 @@ export class QuizPageComponent implements OnInit {
       if (!answer) {
         return;
       }
+
+      this.isAnswerSubmitted.set(true);
 
       if (answer.isCorrect) {
         this.comment.set(successAnswers[getRandomArrayIndex(successAnswers)] ?? 'Great Job!');
@@ -97,12 +102,13 @@ export class QuizPageComponent implements OnInit {
       return;
     }
 
+    this._isTimeExpired.set(true);
+
     this.quizForm.markAllAsTouched();
     this.error = errorAnswers.timeExpired;
-    this.isAnswerSubmitted.set(true);
     this.quizService.answerQuestion(this.topicId(), questionId, {
       answerId: '',
-      isTimeUp: true,
+      isTimeUp: this._isTimeExpired(),
     });
   }
 
@@ -144,11 +150,10 @@ export class QuizPageComponent implements OnInit {
     }
 
     this.error = '';
-    this.isAnswerSubmitted.set(true);
 
     this.quizService.answerQuestion(this.topicId(), questionId, {
       answerId: this.quizForm.controls.answer.value ?? '',
-      isTimeUp: false,
+      isTimeUp: this._isTimeExpired(),
     });
   }
 
@@ -156,6 +161,7 @@ export class QuizPageComponent implements OnInit {
     this.quizService.setNextStep();
     this.error = '';
     this.quizForm.reset();
+    this._isTimeExpired.set(false);
     this.isAnswerSubmitted.set(false);
     this.comment.set('');
     this.answerResult.set(undefined);

--- a/packages/frontend/src/features/quiz/pages/results-page/results-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/results-page/results-page.component.html
@@ -39,5 +39,20 @@
         <app-button link="..">Re-explore topic</app-button>
       </div>
     </div>
+  } @else {
+    <app-empty
+      class="results-page__empty"
+      heading="Couldn't load your score"
+      [headingLevel]="1"
+      description="We&rsquo;re having trouble retrieving your results right now. Please refresh the page or&nbsp;try again in&nbsp;a&nbsp;moment"
+    >
+      <div class="results-page__nav-buttons">
+        <app-button [isSmallButton]="true" (click)="quizService.reloadPage()"
+          >Refresh page</app-button
+        >
+
+        <app-button link="/quiz" [isSmallButton]="true">Back to&nbsp;categories</app-button>
+      </div>
+    </app-empty>
   }
 </app-layout>

--- a/packages/frontend/src/features/quiz/pages/results-page/results-page.component.scss
+++ b/packages/frontend/src/features/quiz/pages/results-page/results-page.component.scss
@@ -71,4 +71,18 @@
       flex-direction: column;
     }
   }
+
+  &__empty {
+    margin: auto;
+  }
+
+  &__nav-buttons {
+    display: flex;
+    gap: var(--spacing-x4);
+    margin-block-start: var(--spacing-x4);
+
+    @include mix.media('s') {
+      flex-direction: column;
+    }
+  }
 }

--- a/packages/frontend/src/features/quiz/pages/results-page/results-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/results-page/results-page.component.ts
@@ -1,7 +1,7 @@
 import { Component, computed, inject, input, type OnInit } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
-import { ButtonComponent } from '@/shared/ui';
+import { ButtonComponent, EmptyComponent } from '@/shared/ui';
 import { LayoutComponent } from '../layout';
 
 import { QuizService } from '../../services';
@@ -13,7 +13,7 @@ import { REWARD_PRAISE } from '../../constants';
 
 @Component({
   selector: 'app-results-page',
-  imports: [ButtonComponent, DecimalPipe, LayoutComponent],
+  imports: [ButtonComponent, DecimalPipe, EmptyComponent, LayoutComponent],
   templateUrl: './results-page.component.html',
   styleUrl: './results-page.component.scss',
   standalone: true,

--- a/packages/frontend/src/features/quiz/services/quiz.service.ts
+++ b/packages/frontend/src/features/quiz/services/quiz.service.ts
@@ -4,6 +4,10 @@ import { finalize } from 'rxjs';
 
 import { environment } from '@/environments/environment';
 
+import { ModalService } from '@/core/services/modal.service';
+
+import { getHttpErrorMessage } from '@/shared/utils/http-error.utilities';
+
 import type {
   GetCategoriesResponseDto,
   GetCategoryResponseDto,
@@ -12,40 +16,16 @@ import type {
   StartTopicResponseDto,
   SubmitAnswerRequestDto,
   SubmitAnswerResponseDto,
-  QuizCategorySummary,
-  QuizCategory,
 } from '@rs-tandem/shared';
+import type { CustomHttpError } from '@/shared/types';
+import type { QuizState } from './quiz.types';
 
 @Injectable({ providedIn: 'root' })
 export class QuizService {
   private readonly _http = inject(HttpClient);
+  private readonly _modalService = inject(ModalService);
 
-  private readonly _state = signal<{
-    data: {
-      categories: QuizCategorySummary[];
-      category: QuizCategory | null;
-      topic: GetTopicResponseDto | null;
-      step: number;
-      answer: SubmitAnswerResponseDto | null;
-      results: GetResultsResponseDto['results'] | null;
-    };
-    loading: {
-      categories: boolean;
-      category: boolean;
-      topic: boolean;
-      step: boolean;
-      answer: boolean;
-      results: boolean;
-    };
-    error: {
-      categories: string;
-      category: string;
-      topic: string;
-      step: string;
-      answer: string;
-      results: string;
-    };
-  }>({
+  private readonly _state = signal<QuizState>({
     data: {
       categories: [],
       category: null,
@@ -61,15 +41,6 @@ export class QuizService {
       step: false,
       answer: false,
       results: false,
-    },
-    // preparations for showing error state of a page or button
-    error: {
-      categories: '',
-      category: '',
-      topic: '',
-      step: '',
-      answer: '',
-      results: '',
     },
   });
 
@@ -111,11 +82,14 @@ export class QuizService {
     }));
   }
 
+  reloadPage() {
+    window.location.reload();
+  }
+
   getCategories() {
     this._state.update((state) => ({
       ...state,
       loading: { ...state.loading, categories: true },
-      error: { ...state.error, categories: '' },
     }));
 
     this._http
@@ -135,12 +109,8 @@ export class QuizService {
             data: { ...state.data, categories: data.categories },
           }));
         },
-        // Add correct types of error in future
-        error: (error: string) => {
-          this._state.update((state) => ({
-            ...state,
-            error: { ...state.error, categories: error },
-          }));
+        error: (error: CustomHttpError) => {
+          this._showError(error);
         },
       });
   }
@@ -150,7 +120,6 @@ export class QuizService {
       ...state,
       data: { ...state.data, category: null },
       loading: { ...state.loading, category: true },
-      error: { ...state.error, category: '' },
     }));
 
     this._http
@@ -167,11 +136,8 @@ export class QuizService {
         next: (data) => {
           this._state.update((state) => ({ ...state, data: { ...state.data, category: data } }));
         },
-        error: (error: string) => {
-          this._state.update((state) => ({
-            ...state,
-            error: { ...state.error, category: error },
-          }));
+        error: (error: CustomHttpError) => {
+          this._showError(error);
         },
       });
   }
@@ -181,7 +147,6 @@ export class QuizService {
       ...state,
       data: { ...state.data, topic: null },
       loading: { ...state.loading, topic: true },
-      error: { ...state.error, topic: '' },
     }));
 
     this._http
@@ -198,11 +163,8 @@ export class QuizService {
         next: (data) => {
           this._state.update((state) => ({ ...state, data: { ...state.data, topic: data } }));
         },
-        error: (error: string) => {
-          this._state.update((state) => ({
-            ...state,
-            error: { ...state.error, topic: error },
-          }));
+        error: (error: CustomHttpError) => {
+          this._showError(error);
         },
       });
   }
@@ -211,7 +173,6 @@ export class QuizService {
     this._state.update((state) => ({
       ...state,
       loading: { ...state.loading, step: true },
-      error: { ...state.error, step: '' },
     }));
 
     this._http
@@ -231,11 +192,8 @@ export class QuizService {
             data: { ...state.data, step: data.step },
           }));
         },
-        error: (error: string) => {
-          this._state.update((state) => ({
-            ...state,
-            error: { ...state.error, step: error },
-          }));
+        error: (error: CustomHttpError) => {
+          this._showError(error);
         },
       });
   }
@@ -244,7 +202,6 @@ export class QuizService {
     this._state.update((state) => ({
       ...state,
       loading: { ...state.loading, answer: true },
-      error: { ...state.error, answer: '' },
     }));
 
     this._http
@@ -267,11 +224,8 @@ export class QuizService {
             data: { ...state.data, answer: data },
           }));
         },
-        error: (error: string) => {
-          this._state.update((state) => ({
-            ...state,
-            error: { ...state.error, answer: error },
-          }));
+        error: (error: CustomHttpError) => {
+          this._showError(error);
         },
       });
   }
@@ -281,7 +235,6 @@ export class QuizService {
       ...state,
       data: { ...state.data, answer: null },
       loading: { ...state.loading, results: true },
-      error: { ...state.error, results: '' },
     }));
 
     this._http
@@ -301,12 +254,17 @@ export class QuizService {
             data: { ...state.data, results: data.results },
           }));
         },
-        error: (error: string) => {
-          this._state.update((state) => ({
-            ...state,
-            error: { ...state.error, results: error },
-          }));
+        error: (error: CustomHttpError) => {
+          this._showError(error);
         },
       });
+  }
+
+  private _showError(error: CustomHttpError) {
+    this._modalService.open({
+      title: `${String(error.error.statusCode || 0)} — ${error.error.error || 'Network Error'}`,
+      message: getHttpErrorMessage(error, 'Unexpected Error'),
+      icon: 'info-outline',
+    });
   }
 }

--- a/packages/frontend/src/features/quiz/services/quiz.types.ts
+++ b/packages/frontend/src/features/quiz/services/quiz.types.ts
@@ -1,0 +1,28 @@
+import type {
+  GetTopicResponseDto,
+  GetResultsResponseDto,
+  SubmitAnswerResponseDto,
+  QuizCategorySummary,
+  QuizCategory,
+} from '@rs-tandem/shared';
+
+interface QuizState {
+  data: {
+    categories: QuizCategorySummary[];
+    category: QuizCategory | null;
+    topic: GetTopicResponseDto | null;
+    step: number;
+    answer: SubmitAnswerResponseDto | null;
+    results: GetResultsResponseDto['results'] | null;
+  };
+  loading: {
+    categories: boolean;
+    category: boolean;
+    topic: boolean;
+    step: boolean;
+    answer: boolean;
+    results: boolean;
+  };
+}
+
+export type { QuizState };

--- a/packages/frontend/src/shared/types/custom-http-error.types.ts
+++ b/packages/frontend/src/shared/types/custom-http-error.types.ts
@@ -1,0 +1,11 @@
+import type { HttpErrorResponse } from '@angular/common/http';
+
+interface CustomHttpError extends HttpErrorResponse {
+  error: {
+    error: string;
+    message: string;
+    statusCode: number;
+  };
+}
+
+export type { CustomHttpError };

--- a/packages/frontend/src/shared/types/index.ts
+++ b/packages/frontend/src/shared/types/index.ts
@@ -1,3 +1,4 @@
 export type { ButtonType } from './dom.types';
+export type { CustomHttpError } from './custom-http-error.types';
 export type { Theme } from './theme.types';
 export type { TeamMember } from './team-member.type';

--- a/packages/frontend/src/shared/ui/empty/empty.component.html
+++ b/packages/frontend/src/shared/ui/empty/empty.component.html
@@ -1,0 +1,17 @@
+<div class="empty">
+  @switch (headingLevel()) {
+    @case (1) {
+      <h1 class="h2">{{ heading() }}</h1>
+    }
+    @case (3) {
+      <h3 class="h3">{{ heading() }}</h3>
+    }
+    @default {
+      <h2 class="h2">{{ heading() }}</h2>
+    }
+  }
+
+  <p class="text-lg-fluid empty__description">{{ description() }}</p>
+
+  <ng-content></ng-content>
+</div>

--- a/packages/frontend/src/shared/ui/empty/empty.component.scss
+++ b/packages/frontend/src/shared/ui/empty/empty.component.scss
@@ -1,0 +1,16 @@
+:host,
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  max-width: 712px;
+
+  text-align: center;
+}
+
+.empty {
+  &__description {
+    margin-block-start: var(--spacing-x4);
+  }
+}

--- a/packages/frontend/src/shared/ui/empty/empty.component.spec.ts
+++ b/packages/frontend/src/shared/ui/empty/empty.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EmptyComponent } from './empty.component';
+
+describe('EmptyComponent', () => {
+  let component: EmptyComponent;
+  let fixture: ComponentFixture<EmptyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmptyComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmptyComponent);
+    fixture.componentRef.setInput('heading', 'Heading');
+    fixture.componentRef.setInput('description', 'Description');
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/shared/ui/empty/empty.component.ts
+++ b/packages/frontend/src/shared/ui/empty/empty.component.ts
@@ -1,0 +1,16 @@
+import { Component, input } from '@angular/core';
+
+import type { HeadingLevel } from './empty.types';
+
+@Component({
+  selector: 'app-empty',
+  imports: [],
+  templateUrl: './empty.component.html',
+  styleUrl: './empty.component.scss',
+  standalone: true,
+})
+export class EmptyComponent {
+  heading = input.required<string>();
+  headingLevel = input<HeadingLevel>(2);
+  description = input.required<string>();
+}

--- a/packages/frontend/src/shared/ui/empty/empty.types.ts
+++ b/packages/frontend/src/shared/ui/empty/empty.types.ts
@@ -1,0 +1,3 @@
+type HeadingLevel = 1 | 2 | 3;
+
+export type { HeadingLevel };

--- a/packages/frontend/src/shared/ui/empty/index.ts
+++ b/packages/frontend/src/shared/ui/empty/index.ts
@@ -1,0 +1,1 @@
+export { EmptyComponent } from './empty.component';

--- a/packages/frontend/src/shared/ui/index.ts
+++ b/packages/frontend/src/shared/ui/index.ts
@@ -2,6 +2,7 @@ export { BreadcrumbComponent } from './breadcrumb';
 export { ButtonComponent } from './button/button.component';
 export { CardComponent } from './card/card.component';
 export { CardFooterDirective } from './card/card-footer.directive';
+export { EmptyComponent } from './empty';
 export { IconButtonComponent } from './icon-button/icon-button.component';
 export { IconComponent } from './icon/icon.component';
 export { LogoComponent } from './logo/logo.component';


### PR DESCRIPTION
### ⚡ **PR: Quiz empty states + centralized API error modal**

---

#### 📋 **Description**

- **What:** Added a reusable `EmptyComponent` and integrated empty states across Quiz pages (Categories, Category, Quiz, Results). Updated `QuizService` to centralize HTTP error handling via `ModalService`, and introduced dedicated types (`QuizState`, `CustomHttpError`).
- **Why:** Improve UX for “no data / failed load” scenarios, reduce duplicated page-level handling, and make quiz state management easier to maintain.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2?pane=issue&itemId=165998849&issue=jsgods-rs-tandem%7Crs-tandem%7C137

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [x] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Go to **Quiz → Categories** and verify:
   - when categories exist: the list renders
   - when categories are empty/unavailable: an empty state is shown with a **Refresh page** action
2. Navigate to a **Category**, **Topic (Quiz)**, and **Results** page and verify empty states appear when data is missing/unavailable, with navigation/refresh actions.
3. Simulate an API error (e.g., disable network or force a 4xx/5xx for quiz endpoints).
4. **Expected result:** A modal appears with the error details; pages do not crash, and empty-state UI is available where applicable.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
<img width="1008" height="754" alt="Screenshot 2026-03-22 at 12 16 15" src="https://github.com/user-attachments/assets/116a7bce-9e3e-493b-83e3-4679dee8c25f" />
<img width="1013" height="757" alt="Screenshot 2026-03-22 at 12 16 23" src="https://github.com/user-attachments/assets/8703340d-2d12-43c3-9de2-2b01126566a2" />
<img width="1009" height="754" alt="Screenshot 2026-03-22 at 12 16 40" src="https://github.com/user-attachments/assets/8cf38475-d993-4885-9ba2-4ebc01528c0c" />
<img width="1007" height="752" alt="Screenshot 2026-03-22 at 12 16 47" src="https://github.com/user-attachments/assets/f2e5426a-d096-42ca-934b-52148ecade0e" />
<img width="1008" height="756" alt="Screenshot 2026-03-22 at 12 17 22" src="https://github.com/user-attachments/assets/2e18772e-ee8a-43d4-9e03-7fcdc59ef787" />
<img width="1005" height="753" alt="Screenshot 2026-03-22 at 12 17 39" src="https://github.com/user-attachments/assets/1427123d-1fdc-4c69-a8b9-8249623ec8c6" />
<img width="1004" height="752" alt="Screenshot 2026-03-22 at 12 17 46" src="https://github.com/user-attachments/assets/040257b6-4e1c-4c6e-8f24-dc80aac04c60" />
<img width="1003" height="756" alt="Screenshot 2026-03-22 at 12 18 05" src="https://github.com/user-attachments/assets/2e050256-9853-4ff1-a9dd-c66e2059c878" />
<img width="1005" height="755" alt="Screenshot 2026-03-22 at 12 18 13" src="https://github.com/user-attachments/assets/b5e3c7c9-eabc-4fe2-9192-e689d67d8c2b" />
