### PR TITLE
feat: add enter and leave animation for mobile menu

### DIFF
--- a/packages/frontend/src/core/components/header/components/mobile-menu/mobile-menu.component.html
+++ b/packages/frontend/src/core/components/header/components/mobile-menu/mobile-menu.component.html
@@ -17,8 +17,21 @@
 </app-button>
 
 @if (isOpen()) {
-  <div class="mobile-menu__backdrop" (click)="onToggle()" aria-hidden="true"></div>
-  <div id="mobile-navigation" class="mobile-menu__panel" role="dialog" aria-modal="true">
+  <div
+    class="mobile-menu__backdrop"
+    (click)="onToggle()"
+    aria-hidden="true"
+    animate.enter="fade-in"
+    animate.leave="fade-out"
+  ></div>
+  <div
+    id="mobile-navigation"
+    class="mobile-menu__panel"
+    role="dialog"
+    aria-modal="true"
+    animate.enter="slide-in"
+    animate.leave="slide-out"
+  >
     <div class="mobile-menu__content">
       @if (layoutService.showSidebar()) {
         <app-navigation [links]="navService.links()" (linkClicked)="onToggle()" />

--- a/packages/frontend/src/core/components/header/components/mobile-menu/mobile-menu.component.scss
+++ b/packages/frontend/src/core/components/header/components/mobile-menu/mobile-menu.component.scss
@@ -103,10 +103,6 @@
 
     background-color: var(--backdrop-color);
     backdrop-filter: blur(2px);
-
-    animation:
-      fadeIn var(--transition-duration-basic),
-      var(--transition-easing-func);
   }
 
   &__panel {
@@ -125,7 +121,6 @@
     background-color: var(--primary-color);
     box-shadow: var(--shadow-mobile-menu);
 
-    animation: slideIn 0.7s cubic-bezier(0.77, 0.2, 0.05, 1);
     @include m.transition(background-color);
   }
 
@@ -135,6 +130,14 @@
     gap: var(--spacing-x6);
     padding: var(--spacing-x6) var(--spacing-x4);
   }
+}
+
+.fade-in {
+  animation: fadeIn var(--transition-duration-basic) ease-out;
+}
+
+.fade-out {
+  animation: fadeOut var(--transition-duration-basic) ease-in;
 }
 
 @keyframes fadeIn {
@@ -147,6 +150,24 @@
   }
 }
 
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+.slide-in {
+  animation: slideIn 0.7s cubic-bezier(0.77, 0.2, 0.05, 1);
+}
+
+.slide-out {
+  animation: slideOut 0.7s cubic-bezier(0.77, 0.2, 0.05, 1);
+}
+
 @keyframes slideIn {
   from {
     transform: translateX(100%);
@@ -156,5 +177,17 @@
   to {
     transform: translateX(0);
     opacity: 1;
+  }
+}
+
+@keyframes slideOut {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+
+  to {
+    transform: translateX(100%);
+    opacity: 0;
   }
 }


### PR DESCRIPTION
### ⚡ **PR: Refactor Mobile Menu Animations**

---

#### 📋 **Description**

- **What:** Integrated Angular's animation to handle the mobile menu transitions.
- **Why:** To fix the issue where the menu vanished instantly on close. Using `animate.leave` allows the closing animation to complete before the element is destroyed.
- **Related Issue:** [#177]

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Open the application on a mobile viewport.
2. Click the hamburger icon to open the menu (observe the enter animation).
3. Click the close button or backdrop to close the menu.
4. **Expected result:** The menu should animate out smoothly instead of disappearing instantly.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

https://github.com/user-attachments/assets/dc764c82-bd06-4c0c-b718-c8ba1909dc55




#### 📸 **Screenshots / GIFs**
