### PR TITLE
fix: use relative path for i18n translation files to respect base href

### DIFF
--- a/packages/frontend/src/app/transloco-loader.ts
+++ b/packages/frontend/src/app/transloco-loader.ts
@@ -7,6 +7,6 @@ export class TranslocoHttpLoader implements TranslocoLoader {
   private http = inject(HttpClient);
 
   getTranslation(lang: string) {
-    return this.http.get<Translation>(`/i18n/${lang}.json`);
+    return this.http.get<Translation>(`i18n/${lang}.json`);
   }
 }


### PR DESCRIPTION
### ⚡ **PR: fix: use relative path for i18n translation files to respect base href**

---

#### 📋 **Description**

- **What:** Changed the i18n translation file path in `TranslocoHttpLoader` from `/i18n/${lang}.json` (root-relative) to `i18n/${lang}.json` (relative).
- **Why:** On GitHub Pages the app is served under `/rs-tandem/`, so the leading `/` caused requests to hit `https://jsgods-rs-tandem.github.io/i18n/en.json` instead of `https://jsgods-rs-tandem.github.io/rs-tandem/i18n/en.json`, breaking translations in production.
- **Related Issue:** N/A

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Deploy the app to GitHub Pages (or build with `--base-href /rs-tandem/`).
2. Open the deployed app and check the Network tab for translation file requests.
3. **Expected result:** Requests go to `/rs-tandem/i18n/en.json` (or the active language), translations load correctly, and no 404 errors appear.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**

N/A — single-line path change with no visual output.