### PR TITLE
fix: close menu on navigation and update animation duration

### DIFF
--- a/packages/frontend/src/assets/styles/index.scss
+++ b/packages/frontend/src/assets/styles/index.scss
@@ -8,7 +8,7 @@
 
 :root {
   --transition-duration-basic: 0.3s;
-  --transition-duration-slow: 0.8s;
+  --transition-duration-slow: 0.6s;
   --transition-duration-extra-slow: 1.5s;
   --transition-easing-func: ease-in-out;
   --code-bg-color: #d8d8d8;
@@ -138,26 +138,25 @@ main {
   object-fit: none;
   object-position: top right;
 
-  animation-duration: var(--transition-duration-slow);
   animation-fill-mode: both;
 }
 
 ::view-transition-old(main) {
   animation-name: page-fade-out;
+  animation-duration: var(--transition-duration-basic);
 }
 
 ::view-transition-new(main) {
   animation-name: page-slide-in-from-top;
+  animation-duration: var(--transition-duration-slow);
 }
 
 @keyframes page-fade-out {
   from {
-    transform: translateY(0);
-    opacity: 1;
+    opacity: 0.5;
   }
 
   to {
-    transform: translateY(100vh);
     opacity: 0;
   }
 }

--- a/packages/frontend/src/core/components/header/components/mobile-menu/mobile-menu.component.scss
+++ b/packages/frontend/src/core/components/header/components/mobile-menu/mobile-menu.component.scss
@@ -164,11 +164,11 @@
 }
 
 .slide-in {
-  animation: slideIn 0.7s cubic-bezier(0.77, 0.2, 0.05, 1);
+  animation: slideIn var(--transition-duration-slow) cubic-bezier(0.77, 0.2, 0.05, 1);
 }
 
 .slide-out {
-  animation: slideOut 0.7s cubic-bezier(0.77, 0.2, 0.05, 1);
+  animation: slideOut var(--transition-duration-basic) cubic-bezier(0.77, 0.2, 0.05, 1);
 }
 
 @keyframes slideIn {

--- a/packages/frontend/src/core/components/header/components/mobile-menu/mobile-menu.component.ts
+++ b/packages/frontend/src/core/components/header/components/mobile-menu/mobile-menu.component.ts
@@ -2,11 +2,13 @@ import { ButtonComponent } from '@/shared/ui';
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   DOCUMENT,
   effect,
   HostListener,
   inject,
   input,
+  OnInit,
   output,
   Renderer2,
 } from '@angular/core';
@@ -14,6 +16,9 @@ import { NavService } from '@/core/services/navigation.service';
 import { LayoutService } from '@/core/services/layout.service';
 import { NavigationComponent } from '@/core/components/navigation/navigation.component';
 import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
+import { filter } from 'rxjs';
+import { NavigationEnd, Router } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   selector: 'app-mobile-menu',
   imports: [ButtonComponent, NavigationComponent, TypedTranslocoPipe],
@@ -21,9 +26,12 @@ import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
   styleUrl: './mobile-menu.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MobileMenuComponent {
+export class MobileMenuComponent implements OnInit {
   private renderer = inject(Renderer2);
   private document = inject(DOCUMENT);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
+
   layoutService = inject(LayoutService);
   navService = inject(NavService);
   isOpen = input<boolean>(false);
@@ -50,6 +58,20 @@ export class MobileMenuComponent {
       this.onToggle();
     }
   }
+
+  ngOnInit(): void {
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        if (this.isOpen()) {
+          this.onToggle();
+        }
+      });
+  }
+
   onToggle(): void {
     this.menuToggled.emit();
   }


### PR DESCRIPTION
### ⚡ **PR: fix: close menu on navigation and update animation duration**

---

#### 📋 **Description**

- **What:**

  - Implemented a subscription to Router events (NavigationEnd) to automatically close the mobile menu when a user navigates to a new route.
  - Adjusted the mobile menu's animation duration for a smoother feel.

- **Why:** Improving UX: Previously, the menu remained open after clicking a link, obscuring the new page content and requiring a manual close.
- **Related Issue:** [#186]

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. [Step 1]
2. [Step 2]
3. **Expected result:** [What should happen?]

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
