### PR TITLE
fix: update state click on breadcrumb links and remove layout shifts

### DIFF
--- a/packages/frontend/src/features/challenges/pages/categories-page/categories-page.component.spec.ts
+++ b/packages/frontend/src/features/challenges/pages/categories-page/categories-page.component.spec.ts
@@ -19,6 +19,7 @@ describe('CategoriesPageComponent', () => {
           provide: ChallengesService,
           useValue: {
             getCategories: () => void 0,
+            resetCategories: () => void 0,
             categories: () => [],
             loading: () => ({
               categories: false,

--- a/packages/frontend/src/features/challenges/pages/categories-page/categories-page.component.ts
+++ b/packages/frontend/src/features/challenges/pages/categories-page/categories-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, type OnInit } from '@angular/core';
+import { Component, effect, inject, type OnInit } from '@angular/core';
 
 import { LayoutComponent } from '@/pages/layout';
 import { ButtonComponent, CategoryCardListComponent, EmptyComponent } from '@/shared/ui';
@@ -14,6 +14,14 @@ import { ChallengesService } from '../../services';
 })
 export class CategoriesPageComponent implements OnInit {
   readonly challengesService = inject(ChallengesService);
+
+  constructor() {
+    effect((onCleanup) => {
+      onCleanup(() => {
+        this.challengesService.resetCategories();
+      });
+    });
+  }
 
   ngOnInit(): void {
     this.challengesService.getCategories();

--- a/packages/frontend/src/features/challenges/pages/category-page/category-page.component.spec.ts
+++ b/packages/frontend/src/features/challenges/pages/category-page/category-page.component.spec.ts
@@ -19,6 +19,7 @@ describe('CategoryPageComponent', () => {
           provide: ChallengesService,
           useValue: {
             getCategory: () => void 0,
+            resetCategory: () => void 0,
             reloadPage: () => void 0,
             category: () => null,
             loading: () => ({

--- a/packages/frontend/src/features/challenges/pages/category-page/category-page.component.ts
+++ b/packages/frontend/src/features/challenges/pages/category-page/category-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, type OnInit } from '@angular/core';
+import { Component, effect, inject, input, type OnInit } from '@angular/core';
 
 import { LayoutComponent } from '@/pages/layout';
 import { ButtonComponent, EmptyComponent, ProgressComponent } from '@/shared/ui';
@@ -23,10 +23,18 @@ export class CategoryPageComponent implements OnInit {
   readonly challengesService = inject(ChallengesService);
   readonly categoryId = input.required<string>();
 
-  ngOnInit(): void {
-    const categoryId = this.categoryId();
+  constructor() {
+    effect((onCleanup) => {
+      onCleanup(() => {
+        this.challengesService.resetCategory();
+      });
+    });
+  }
 
-    if (this.challengesService.category()?.id !== categoryId) {
+  ngOnInit(): void {
+    if (!this.challengesService.category()) {
+      const categoryId = this.categoryId();
+
       this.challengesService.getCategory(categoryId);
     }
   }

--- a/packages/frontend/src/features/challenges/pages/code-editor-page/code-editor-page.component.spec.ts
+++ b/packages/frontend/src/features/challenges/pages/code-editor-page/code-editor-page.component.spec.ts
@@ -37,6 +37,7 @@ describe('CodeEditorPageComponent', () => {
             }),
             reloadPage: () => void 0,
             postTopicStatus: () => void 0,
+            resetCodeEditor: () => void 0,
           } as unknown as ChallengesService,
         },
       ],

--- a/packages/frontend/src/features/challenges/pages/code-editor-page/code-editor-page.component.ts
+++ b/packages/frontend/src/features/challenges/pages/code-editor-page/code-editor-page.component.ts
@@ -95,6 +95,12 @@ export class CodeEditorPageComponent implements OnInit {
         this._applyMonacoTheme();
       });
     });
+
+    effect((onCleanup) => {
+      onCleanup(() => {
+        this.challengesService.resetCodeEditor();
+      });
+    });
   }
 
   ngOnInit() {

--- a/packages/frontend/src/features/challenges/services/challenges.service.ts
+++ b/packages/frontend/src/features/challenges/services/challenges.service.ts
@@ -176,6 +176,36 @@ export class ChallengesService {
       });
   }
 
+  resetCategories() {
+    this._state.update((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        categories: [],
+      },
+    }));
+  }
+
+  resetCategory() {
+    this._state.update((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        category: null,
+      },
+    }));
+  }
+
+  resetCodeEditor() {
+    this._state.update((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        codeEditor: null,
+      },
+    }));
+  }
+
   private _showError(error: CustomHttpError) {
     const errorMessage = getHttpErrorMessage(error);
     const translateKey = (message: string) => this._t(marker(message as AppTranslationKey));

--- a/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/categories-page/categories-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, type OnInit } from '@angular/core';
+import { Component, effect, inject, type OnInit } from '@angular/core';
 
 import { ButtonComponent, CategoryCardListComponent, EmptyComponent } from '@/shared/ui';
 import { LayoutComponent } from '@/pages/layout';
@@ -14,6 +14,14 @@ import { QuizService } from '../../services';
 })
 export class CategoriesPageComponent implements OnInit {
   readonly quizService = inject(QuizService);
+
+  constructor() {
+    effect((onCleanup) => {
+      onCleanup(() => {
+        this.quizService.resetCategories();
+      });
+    });
+  }
 
   ngOnInit(): void {
     this.quizService.getCategories();

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.spec.ts
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.spec.ts
@@ -17,6 +17,7 @@ describe('CategoryPageComponent', () => {
           provide: QuizService,
           useValue: {
             getCategory: () => void 0,
+            resetCategory: () => void 0,
             category: () => null,
             loading: () => ({
               categories: false,

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, type OnInit } from '@angular/core';
+import { Component, effect, inject, input, type OnInit } from '@angular/core';
 
 import { ButtonComponent, EmptyComponent, ProgressComponent } from '@/shared/ui';
 import { LayoutComponent } from '@/pages/layout';
@@ -23,10 +23,18 @@ export class CategoryPageComponent implements OnInit {
   readonly quizService = inject(QuizService);
   readonly categoryId = input.required<string>();
 
-  ngOnInit(): void {
-    const categoryId = this.categoryId();
+  constructor() {
+    effect((onCleanup) => {
+      onCleanup(() => {
+        this.quizService.resetCategory();
+      });
+    });
+  }
 
-    if (this.quizService.category()?.id !== categoryId) {
+  ngOnInit(): void {
+    if (!this.quizService.category()) {
+      const categoryId = this.categoryId();
+
       this.quizService.getCategory(categoryId);
     }
   }

--- a/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.html
@@ -3,7 +3,7 @@
 @let step = quizService.step();
 @let loading = quizService.loading();
 
-<app-layout [loading]="loading.topic || loading.results">
+<app-layout [loading]="loading.topic || loading.results || loading.step">
   @if (topic && question) {
     <header>
       <h1 class="h2">{{ topic.name }}</h1>

--- a/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.spec.ts
+++ b/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.spec.ts
@@ -20,6 +20,7 @@ describe('QuizPageComponent', () => {
             startTopic: () => void 0,
             answerQuestion: () => void 0,
             setNextStep: () => void 0,
+            resetTopic: () => void 0,
             topic: () => null,
             currentQuestion: () => null,
             step: () => 0,

--- a/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/quiz-page/quiz-page.component.ts
@@ -82,6 +82,12 @@ export class QuizPageComponent implements OnInit {
       this.quizForm.controls.answer.disable();
       this._checkQuizCompletion();
     });
+
+    effect((onCleanup) => {
+      onCleanup(() => {
+        this.quizService.resetTopic();
+      });
+    });
   }
 
   ngOnInit(): void {

--- a/packages/frontend/src/features/quiz/pages/results-page/results-page.component.spec.ts
+++ b/packages/frontend/src/features/quiz/pages/results-page/results-page.component.spec.ts
@@ -17,6 +17,7 @@ describe('ResultsPageComponent', () => {
           provide: QuizService,
           useValue: {
             getResults: () => void 0,
+            resetResults: () => void 0,
             results: () => null,
             loading: () => ({
               categories: false,

--- a/packages/frontend/src/features/quiz/pages/results-page/results-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/results-page/results-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, type OnInit } from '@angular/core';
+import { Component, computed, effect, inject, input, type OnInit } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
 import { LayoutComponent } from '@/pages/layout';
@@ -25,6 +25,14 @@ export class ResultsPageComponent implements OnInit {
   readonly topicId = input.required<string>();
 
   readonly ROUTE_PATHS = ROUTE_PATHS;
+
+  constructor() {
+    effect((onCleanup) => {
+      onCleanup(() => {
+        this.quizService.resetResults();
+      });
+    });
+  }
 
   ngOnInit(): void {
     this.quizService.getResults(this.topicId());

--- a/packages/frontend/src/features/quiz/services/quiz.service.ts
+++ b/packages/frontend/src/features/quiz/services/quiz.service.ts
@@ -263,6 +263,46 @@ export class QuizService {
       });
   }
 
+  resetCategories() {
+    this._state.update((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        categories: [],
+      },
+    }));
+  }
+
+  resetCategory() {
+    this._state.update((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        category: null,
+      },
+    }));
+  }
+
+  resetTopic() {
+    this._state.update((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        topic: null,
+      },
+    }));
+  }
+
+  resetResults() {
+    this._state.update((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        results: null,
+      },
+    }));
+  }
+
   private _showError(error: CustomHttpError) {
     const errorMessage = getHttpErrorMessage(error);
     const translateKey = (message: string) => this._t(marker(message as AppTranslationKey));


### PR DESCRIPTION
### ⚡ **PR: Fix Breadcrumb State Updates and Quiz Step Restoration**

---

#### 📋 **Description**

- **What:** Fixed state updates after navigation via breadcrumb links and corrected quiz step restoration so the saved step is applied immediately without rendering the initial step first. Also updated related component tests to reflect the new cleanup/state behavior.
- **Why:** This was necessary to keep page state consistent after breadcrumb navigation and to remove the visual flicker/jump when reopening an in-progress quiz.
- **Related Issue:**
https://github.com/orgs/jsgods-rs-tandem/projects/2?pane=issue&itemId=172657711&issue=jsgods-rs-tandem%7Crs-tandem%7C215 
https://github.com/orgs/jsgods-rs-tandem/projects/2/views/1?pane=issue&itemId=172658370&issue=jsgods-rs-tandem%7Crs-tandem%7C217

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Open quiz or challenges pages and navigate using the breadcrumb links.
2. Reopen a quiz that was previously stopped on a step other than the first one.
3. **Expected result:** State updates correctly after breadcrumb navigation, and the quiz opens directly on the saved step without flashing step 1 first.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
N/A