### PR TITLE
fix: lazy load QuickJS WASM with correct base path

### DIFF
--- a/packages/frontend/src/features/challenges/workers/quickjs-executor.worker.ts
+++ b/packages/frontend/src/features/challenges/workers/quickjs-executor.worker.ts
@@ -85,13 +85,23 @@ const deepEqual = (a: unknown, b: unknown, seen = new WeakMap<object, object>())
   return true;
 };
 
-const quickJsWasmUrl = new URL('/assets/quickjs/emscripten-module.wasm', self.location.href).href;
+let quickJsModulePromise: ReturnType<typeof newQuickJSWASMModule> | null = null;
 
-const quickJsVariant = newVariant(RELEASE_SYNC, {
-  wasmLocation: quickJsWasmUrl,
-});
+const getQuickJSModule = async () => {
+  if (quickJsModulePromise) {
+    return quickJsModulePromise;
+  }
 
-const QuickJSModulePromise = newQuickJSWASMModule(quickJsVariant);
+  const baseUrl = self.location.href.includes('/rs-tandem/') ? '/rs-tandem' : '';
+  const quickJsWasmUrl = `${baseUrl}/assets/quickjs/emscripten-module.wasm`;
+
+  const quickJsVariant = newVariant(RELEASE_SYNC, {
+    wasmLocation: quickJsWasmUrl,
+  });
+
+  quickJsModulePromise = newQuickJSWASMModule(quickJsVariant);
+  return quickJsModulePromise;
+};
 
 const readErrorMessage = (dumped: unknown): string => {
   if (!isRecord(dumped)) return '';
@@ -140,7 +150,7 @@ async function runQuickJs(data: QuickJsWorkerRequest): Promise<void> {
   };
 
   try {
-    const QuickJS = await QuickJSModulePromise;
+    const QuickJS = await getQuickJSModule();
     const vm = QuickJS.newContext();
 
     vm.runtime.setInterruptHandler(shouldInterruptAfterDeadline(Date.now() + 2800));


### PR DESCRIPTION
### ⚡ **PR: Fix QuickJS WASM URL for GitHub Pages base path**

---

#### 📋 **Description**

- **What:** Replaced the eagerly-evaluated WASM URL with a lazy-loaded `getQuickJSModule()` function that detects the correct base path at runtime.
- **Why:** When deployed to GitHub Pages under the `/rs-tandem/` sub-path, the WASM file was being requested from `/assets/...` (root) instead of `/rs-tandem/assets/...`, causing the QuickJS executor to fail silently. The fix detects whether the worker is running under the `/rs-tandem/` prefix and prepends it accordingly.
- **Related Issue:** N/A

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Deploy the app to GitHub Pages (or serve it locally under a `/rs-tandem/` sub-path).
2. Navigate to any challenge and run the code evaluator.
3. **Expected result:** The QuickJS WASM loads successfully and code execution works without errors.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**