### PR TITLE
feat: create ui select component and filters in challenges and quiz modules

### DIFF
--- a/packages/frontend/public/i18n/en.json
+++ b/packages/frontend/public/i18n/en.json
@@ -306,6 +306,9 @@
   "ui": {
     "progress": {
       "popover": "Completed"
+    },
+    "select": {
+      "placeholderSelected": "Selected"
     }
   },
   "library": {
@@ -340,8 +343,28 @@
       }
     },
     "category": {
+      "filters": {
+        "difficulty": {
+          "label": "Difficulty",
+          "placeholder": "Select difficulty"
+        },
+        "tags": {
+          "label": "Tags",
+          "placeholder": "Select tags"
+        },
+        "status": {
+          "label": "Status",
+          "placeholder": "Select status"
+        },
+        "empty": {
+          "heading": "No\u00A0results found",
+          "description": "Try adjusting your filters or\u00A0resetting them to\u00A0see more options"
+        },
+        "resetButton": "Reset filters"
+      },
       "previewCard": {
         "badges": {
+          "notStarted": "Not started",
           "inProgress": "In\u00A0progress",
           "done": "Done"
         },
@@ -408,6 +431,21 @@
       }
     },
     "category": {
+      "filters": {
+        "achievements": {
+          "label": "Achievements",
+          "placeholder": "Select achievements"
+        },
+        "status": {
+          "label": "Status",
+          "placeholder": "Select status"
+        },
+        "empty": {
+          "heading": "No\u00A0results found",
+          "description": "Try adjusting your filters or\u00A0resetting them to\u00A0see more options"
+        },
+        "resetButton": "Reset filters"
+      },
       "empty": {
         "heading": "Category is currently empty",
         "description": "We couldn't find any quizzes in this category right now. Try refreshing the page or\u00A0explore other categories",
@@ -421,7 +459,9 @@
         "multiple": "{{count}} questions"
       },
       "badges": {
+        "notStarted": "Not started",
         "inProgress": "In progress",
+        "done": "Done",
         "level": {
           "senior": "Senior",
           "middle": "Middle",

--- a/packages/frontend/public/i18n/ru.json
+++ b/packages/frontend/public/i18n/ru.json
@@ -308,6 +308,9 @@
   "ui": {
     "progress": {
       "popover": "Завершено"
+    },
+    "select": {
+      "placeholderSelected": "Выбрано"
     }
   },
   "library": {
@@ -342,8 +345,28 @@
       }
     },
     "category": {
+      "filters": {
+        "difficulty": {
+          "label": "Сложность",
+          "placeholder": "Выберите сложность"
+        },
+        "tags": {
+          "label": "Теги",
+          "placeholder": "Выберите теги"
+        },
+        "status": {
+          "label": "Статус",
+          "placeholder": "Выберите статус"
+        },
+        "empty": {
+          "heading": "Ничего не\u00A0найдено",
+          "description": "Попробуйте изменить параметры фильтрации или сбросить настройки"
+        },
+        "resetButton": "Сбросить фильтры"
+      },
       "previewCard": {
         "badges": {
+          "notStarted": "Не\u00A0начато",
           "inProgress": "В\u00A0работе",
           "done": "Готово"
         },
@@ -410,6 +433,21 @@
       }
     },
     "category": {
+      "filters": {
+        "achievements": {
+          "label": "Достижения",
+          "placeholder": "Выберите достижения"
+        },
+        "status": {
+          "label": "Статус",
+          "placeholder": "Выберите статус"
+        },
+        "empty": {
+          "heading": "Ничего не\u00A0найдено",
+          "description": "Попробуйте изменить параметры фильтрации или сбросить настройки"
+        },
+        "resetButton": "Сбросить фильтры"
+      },
       "empty": {
         "heading": "Категория пока пуста",
         "description": "Мы\u00A0не\u00A0нашли квизов в\u00A0этой категории. Попробуйте обновить страницу или перейти в\u00A0другие категории",
@@ -423,14 +461,16 @@
         "multiple": "{{count}} вопросов"
       },
       "badges": {
+        "notStarted": "Не\u00A0начато",
         "inProgress": "В\u00A0работе",
+        "done": "Готово",
         "level": {
-          "senior": "Senior",
-          "middle": "Middle",
-          "junior": "Junior",
-          "trainee": "Trainee"
+          "senior": "Сеньор",
+          "middle": "Мидл",
+          "junior": "Джуниор",
+          "trainee": "Трейни"
         },
-        "popover": "90%+ Senior\n70%+ Middle\n50%+ Junior"
+        "popover": "90%+ Сеньор\n70%+ Мидл\n50%+ Джуниор"
       },
       "startButton": "Начать тему"
     },

--- a/packages/frontend/src/assets/styles/index.scss
+++ b/packages/frontend/src/assets/styles/index.scss
@@ -35,6 +35,7 @@
   --spacing-x9: calc(var(--spacing-module) * 9);
   --spacing-x10: calc(var(--spacing-module) * 10);
   --spacing-x11: calc(var(--spacing-module) * 11);
+  --spacing-x12: calc(var(--spacing-module) * 12);
   --spacing-x13: calc(var(--spacing-module) * 13);
   --radius-xs: 2px;
   --radius-sm: 4px;

--- a/packages/frontend/src/features/challenges/pages/category-page/category-page.component.html
+++ b/packages/frontend/src/features/challenges/pages/category-page/category-page.component.html
@@ -1,5 +1,7 @@
-@let category = challengesService.category();
-@let loading = challengesService.loading();
+@let category = _challengesService.category();
+@let filters = _filtersValues();
+@let topics = _topics();
+@let loading = _challengesService.loading();
 
 <app-layout [loading]="loading.category || loading.codeEditor">
   @if (category) {
@@ -14,21 +16,66 @@
       />
     </header>
 
-    <ul class="category-page__list">
-      @for (topic of category.topics; track topic.id) {
-        <li>
-          <app-challenge-preview-card
-            [id]="topic.id"
-            [heading]="topic.name"
-            [description]="topic.description"
-            [difficulty]="topic.difficulty"
-            [tags]="topic.tags"
-            [inProgress]="topic.status === 'inProgress'"
-            [isComplete]="topic.status === 'completed'"
-          />
-        </li>
+    <div class="category-page__body">
+      <div class="category-page__filters">
+        <app-select
+          [label]="'challenges.category.filters.difficulty.label' | transloco"
+          [placeholder]="'challenges.category.filters.difficulty.placeholder' | transloco"
+          [options]="_difficultyFilter()"
+          [selectedOptionValues]="filters.difficulty"
+          (selectedOptionValuesChange)="_onFilterChange('difficulty', $event)"
+        />
+
+        <app-select
+          [label]="'challenges.category.filters.tags.label' | transloco"
+          [placeholder]="'challenges.category.filters.tags.placeholder' | transloco"
+          [options]="_tagsFilter()"
+          [selectedOptionValues]="filters.tags"
+          (selectedOptionValuesChange)="_onFilterChange('tags', $event)"
+        />
+
+        <app-select
+          class="category-page__filter-status"
+          [label]="'challenges.category.filters.status.label' | transloco"
+          [placeholder]="'challenges.category.filters.status.placeholder' | transloco"
+          [options]="_statusFilter()"
+          [selectedOptionValues]="filters.status"
+          (selectedOptionValuesChange)="_onFilterChange('status', $event)"
+        />
+      </div>
+
+      @if (topics.length > 0) {
+        <ul class="category-page__list">
+          @for (topic of topics; track topic.id) {
+            <li>
+              <app-challenge-preview-card
+                [id]="topic.id"
+                [heading]="topic.name"
+                [description]="topic.description"
+                [difficulty]="topic.difficulty"
+                [tags]="topic.tags"
+                [inProgress]="topic.status === 'inProgress'"
+                [isComplete]="topic.status === 'completed'"
+              />
+            </li>
+          }
+        </ul>
+      } @else {
+        <app-empty
+          class="category-page__empty-filters"
+          [heading]="'challenges.category.filters.empty.heading' | transloco"
+          [headingLevel]="2"
+          [description]="'challenges.category.filters.empty.description' | transloco"
+        >
+          <app-button
+            class="category-page__reset-filters-button"
+            [isSmallButton]="true"
+            (click)="_onFiltersReset()"
+            >{{ 'challenges.category.filters.resetButton' | transloco }}</app-button
+          >
+        </app-empty>
       }
-    </ul>
+    </div>
   } @else {
     <app-empty
       class="category-page__empty"
@@ -37,7 +84,7 @@
       [description]="'challenges.category.empty.description' | transloco"
     >
       <div class="category-page__nav-buttons">
-        <app-button [isSmallButton]="true" (click)="challengesService.reloadPage()">{{
+        <app-button [isSmallButton]="true" (click)="_challengesService.reloadPage()">{{
           'challenges.category.empty.refreshButton' | transloco
         }}</app-button>
 

--- a/packages/frontend/src/features/challenges/pages/category-page/category-page.component.scss
+++ b/packages/frontend/src/features/challenges/pages/category-page/category-page.component.scss
@@ -24,11 +24,48 @@
     max-width: 300px;
   }
 
+  &__body {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    margin-block-start: var(--spacing-x10);
+  }
+
+  &__filters {
+    display: flex;
+    gap: var(--spacing-x2);
+
+    @include mix.media('m') {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @include mix.media('xs') {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__filter-status {
+    grid-column: 1 / 3;
+
+    @include mix.media('xs') {
+      grid-column: auto;
+    }
+  }
+
   &__list {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-x5);
-    margin-block-start: var(--spacing-x10);
+    margin-block-start: var(--spacing-x6);
+  }
+
+  &__empty-filters {
+    margin: calc(var(--spacing-x12) * 2) auto;
+  }
+
+  &__reset-filters-button {
+    margin-block-start: var(--spacing-x4);
   }
 
   &__empty {

--- a/packages/frontend/src/features/challenges/pages/category-page/category-page.component.ts
+++ b/packages/frontend/src/features/challenges/pages/category-page/category-page.component.ts
@@ -1,13 +1,23 @@
-import { Component, effect, inject, input, type OnInit } from '@angular/core';
+import { Component, computed, effect, inject, input, signal, type OnInit } from '@angular/core';
+import { marker } from '@jsverse/transloco-keys-manager/marker';
 
 import { LayoutComponent } from '@/pages/layout';
-import { ButtonComponent, EmptyComponent, ProgressComponent } from '@/shared/ui';
+import {
+  ButtonComponent,
+  EmptyComponent,
+  ProgressComponent,
+  SelectComponent,
+  type SelectOption,
+} from '@/shared/ui';
 import { ChallengePreviewCardComponent } from '../../ui';
 
 import { ChallengesService } from '../../services';
 
-import { injectActiveLang } from '@/shared/utils/translate.utilities';
+import { injectActiveLang, injectTranslate } from '@/shared/utils/translate.utilities';
 import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
+
+import type { AppTranslationKey } from '@/shared/types/translation-keys';
+import type { Filters } from './category-page.types';
 
 @Component({
   selector: 'app-category-page',
@@ -17,6 +27,7 @@ import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
     EmptyComponent,
     LayoutComponent,
     ProgressComponent,
+    SelectComponent,
     TypedTranslocoPipe,
   ],
   templateUrl: './category-page.component.html',
@@ -24,10 +35,12 @@ import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
   standalone: true,
 })
 export class CategoryPageComponent implements OnInit {
-  readonly challengesService = inject(ChallengesService);
   readonly categoryId = input.required<string>();
-  private readonly _activeLang = injectActiveLang();
 
+  protected readonly _challengesService = inject(ChallengesService);
+
+  private readonly _activeLang = injectActiveLang();
+  private readonly _t = injectTranslate();
   private _isInitialLangEffectRun = true;
 
   constructor() {
@@ -41,23 +54,120 @@ export class CategoryPageComponent implements OnInit {
           return;
         }
 
-        this.challengesService.getCategory(categoryId);
+        this._challengesService.getCategory(categoryId);
       },
       { allowSignalWrites: true },
     );
 
     effect((onCleanup) => {
       onCleanup(() => {
-        this.challengesService.resetCategory();
+        this._challengesService.resetCategory();
       });
     });
   }
 
   ngOnInit(): void {
-    if (!this.challengesService.category()) {
+    if (!this._challengesService.category()) {
       const categoryId = this.categoryId();
 
-      this.challengesService.getCategory(categoryId);
+      this._challengesService.getCategory(categoryId);
     }
+  }
+
+  protected _topics = computed(() => {
+    const topics = this._challengesService.category()?.topics ?? [];
+    const filters = this._filtersValues();
+
+    return topics.reduce<typeof topics>((acc, topic) => {
+      if (filters.difficulty.length > 0 && !filters.difficulty.includes(topic.difficulty)) {
+        return acc;
+      }
+
+      if (filters.tags.length > 0 && !topic.tags.some((tag) => filters.tags.includes(tag))) {
+        return acc;
+      }
+
+      if (filters.status.length > 0 && !filters.status.includes(topic.status)) {
+        return acc;
+      }
+
+      acc.push(topic);
+      return acc;
+    }, []);
+  });
+
+  protected _difficultyFilter = computed(() => {
+    this._activeLang();
+
+    return this._computeFilterOptions([
+      {
+        text: 'challenges.category.previewCard.difficulty.easy',
+        value: 'easy',
+      },
+      {
+        text: 'challenges.category.previewCard.difficulty.medium',
+        value: 'medium',
+      },
+      {
+        text: 'challenges.category.previewCard.difficulty.hard',
+        value: 'hard',
+      },
+    ]);
+  });
+
+  protected _tagsFilter = computed(() => {
+    const category = this._challengesService.category();
+    const tags = new Set<string>();
+
+    category?.topics.forEach((topic) => {
+      topic.tags.forEach((tag) => {
+        tags.add(tag);
+      });
+    });
+
+    return Array.from(tags)
+      .map((tag) => ({
+        text: tag,
+        value: tag,
+      }))
+      .sort((a, b) => a.text.localeCompare(b.text));
+  });
+
+  protected _statusFilter = computed(() => {
+    this._activeLang();
+
+    return this._computeFilterOptions([
+      { text: 'challenges.category.previewCard.badges.notStarted', value: 'notStarted' },
+      { text: 'challenges.category.previewCard.badges.inProgress', value: 'inProgress' },
+      { text: 'challenges.category.previewCard.badges.done', value: 'completed' },
+    ]);
+  });
+
+  protected _filtersValues = signal<Filters>({
+    difficulty: [],
+    tags: [],
+    status: [],
+  });
+
+  protected _onFilterChange(type: keyof Filters, selectedOptionValues: string[]) {
+    this._filtersValues.update((previousState) => ({
+      ...previousState,
+      [type]: selectedOptionValues,
+    }));
+  }
+
+  protected _onFiltersReset() {
+    this._filtersValues.set({
+      difficulty: [],
+      tags: [],
+      status: [],
+    });
+  }
+
+  private _computeFilterOptions(options: SelectOption[]) {
+    return options.map(({ text, value }) => ({
+      text: this._t(marker(text as AppTranslationKey)),
+      value,
+    }));
   }
 }

--- a/packages/frontend/src/features/challenges/pages/category-page/category-page.types.ts
+++ b/packages/frontend/src/features/challenges/pages/category-page/category-page.types.ts
@@ -1,0 +1,7 @@
+interface Filters {
+  difficulty: string[];
+  tags: string[];
+  status: string[];
+}
+
+export type { Filters };

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.html
@@ -1,5 +1,7 @@
-@let category = quizService.category();
-@let loading = quizService.loading();
+@let category = _quizService.category();
+@let filters = _filtersValues();
+@let topics = _topics();
+@let loading = _quizService.loading();
 
 <app-layout [loading]="loading.category || loading.topic">
   @if (category) {
@@ -14,7 +16,43 @@
       />
     </header>
 
-    <app-topic-card-list class="category-page__topic-card-list" [topics]="category.topics" />
+    <div class="category-page__body">
+      <div class="category-page__filters">
+        <app-select
+          [label]="'quiz.category.filters.achievements.label' | transloco"
+          [placeholder]="'quiz.category.filters.achievements.placeholder' | transloco"
+          [options]="_achievementsFilter()"
+          [selectedOptionValues]="filters.achievements"
+          (selectedOptionValuesChange)="_onFilterChange('achievements', $event)"
+        />
+
+        <app-select
+          [label]="'quiz.category.filters.status.label' | transloco"
+          [placeholder]="'quiz.category.filters.status.placeholder' | transloco"
+          [options]="_statusFilter()"
+          [selectedOptionValues]="filters.status"
+          (selectedOptionValuesChange)="_onFilterChange('status', $event)"
+        />
+      </div>
+
+      @if (topics.length > 0) {
+        <app-topic-card-list class="category-page__topic-card-list" [topics]="topics" />
+      } @else {
+        <app-empty
+          class="category-page__empty-filters"
+          [heading]="'quiz.category.filters.empty.heading' | transloco"
+          [headingLevel]="2"
+          [description]="'quiz.category.filters.empty.description' | transloco"
+        >
+          <app-button
+            class="category-page__reset-filters-button"
+            [isSmallButton]="true"
+            (click)="_onFiltersReset()"
+            >{{ 'challenges.category.filters.resetButton' | transloco }}</app-button
+          >
+        </app-empty>
+      }
+    </div>
   } @else {
     <app-empty
       class="category-page__empty"
@@ -23,7 +61,7 @@
       [description]="'quiz.category.empty.description' | transloco"
     >
       <div class="category-page__nav-buttons">
-        <app-button [isSmallButton]="true" (click)="quizService.reloadPage()">{{
+        <app-button [isSmallButton]="true" (click)="_quizService.reloadPage()">{{
           'quiz.category.empty.refreshButton' | transloco
         }}</app-button>
 

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.scss
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.scss
@@ -24,8 +24,37 @@
     max-width: 300px;
   }
 
-  &__topic-card-list {
+  &__body {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
     margin-block-start: var(--spacing-x10);
+  }
+
+  &__filters {
+    display: flex;
+    gap: var(--spacing-x2);
+
+    @include mix.media('m') {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @include mix.media('xs') {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__topic-card-list {
+    margin-block-start: var(--spacing-x6);
+  }
+
+  &__empty-filters {
+    margin: calc(var(--spacing-x12) * 2) auto;
+  }
+
+  &__reset-filters-button {
+    margin-block-start: var(--spacing-x4);
   }
 
   &__empty {

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.ts
@@ -1,12 +1,27 @@
-import { Component, effect, inject, input, type OnInit } from '@angular/core';
+import { Component, computed, effect, inject, input, signal, type OnInit } from '@angular/core';
+import { marker } from '@jsverse/transloco-keys-manager/marker';
 
-import { ButtonComponent, EmptyComponent, ProgressComponent } from '@/shared/ui';
+import {
+  ButtonComponent,
+  EmptyComponent,
+  ProgressComponent,
+  SelectComponent,
+  type SelectOption,
+} from '@/shared/ui';
 import { LayoutComponent } from '@/pages/layout';
 import { TopicCardListComponent } from '../../ui';
 
 import { QuizService } from '../../services';
 
+import { injectActiveLang, injectTranslate } from '@/shared/utils/translate.utilities';
 import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
+
+import { computeRewardLevel } from '../../utilities';
+
+import { REWARD_LEVEL } from '../../constants';
+
+import type { AppTranslationKey } from '@/shared/types/translation-keys';
+import type { Filters } from './category-page.types';
 
 @Component({
   selector: 'app-category-page',
@@ -15,6 +30,7 @@ import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
     EmptyComponent,
     LayoutComponent,
     ProgressComponent,
+    SelectComponent,
     TopicCardListComponent,
     TypedTranslocoPipe,
   ],
@@ -23,22 +39,109 @@ import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
   standalone: true,
 })
 export class CategoryPageComponent implements OnInit {
-  readonly quizService = inject(QuizService);
   readonly categoryId = input.required<string>();
+
+  protected readonly _quizService = inject(QuizService);
+
+  private readonly _activeLang = injectActiveLang();
+  private readonly _t = injectTranslate();
 
   constructor() {
     effect((onCleanup) => {
       onCleanup(() => {
-        this.quizService.resetCategory();
+        this._quizService.resetCategory();
       });
     });
   }
 
   ngOnInit(): void {
-    if (!this.quizService.category()) {
+    if (!this._quizService.category()) {
       const categoryId = this.categoryId();
 
-      this.quizService.getCategory(categoryId);
+      this._quizService.getCategory(categoryId);
     }
+  }
+
+  protected _topics = computed(() => {
+    const topics = this._quizService.category()?.topics ?? [];
+    const { achievements, status } = this._filtersValues();
+
+    return topics.reduce<typeof topics>((acc, topic) => {
+      const { score } = topic;
+
+      if (status.length > 0) {
+        if (score === null && !status.includes('notStarted')) {
+          return acc;
+        }
+
+        if (topic.inProgress && !status.includes('inProgress')) {
+          return acc;
+        }
+
+        if (!topic.inProgress && typeof score === 'number' && !status.includes('completed')) {
+          return acc;
+        }
+      }
+
+      if (achievements.length > 0) {
+        if (typeof score !== 'number') {
+          return acc;
+        }
+
+        if (!achievements.includes(computeRewardLevel(score))) {
+          return acc;
+        }
+      }
+
+      acc.push(topic);
+      return acc;
+    }, []);
+  });
+
+  protected _achievementsFilter = computed(() => {
+    this._activeLang();
+
+    return this._computeFilterOptions([
+      { text: 'quiz.topicCard.badges.level.senior', value: REWARD_LEVEL.senior },
+      { text: 'quiz.topicCard.badges.level.middle', value: REWARD_LEVEL.middle },
+      { text: 'quiz.topicCard.badges.level.junior', value: REWARD_LEVEL.junior },
+      { text: 'quiz.topicCard.badges.level.trainee', value: REWARD_LEVEL.trainee },
+    ]);
+  });
+
+  protected _statusFilter = computed(() => {
+    this._activeLang();
+
+    return this._computeFilterOptions([
+      { text: 'quiz.topicCard.badges.notStarted', value: 'notStarted' },
+      { text: 'quiz.topicCard.badges.inProgress', value: 'inProgress' },
+      { text: 'quiz.topicCard.badges.done', value: 'completed' },
+    ]);
+  });
+
+  protected _filtersValues = signal<Filters>({
+    achievements: [],
+    status: [],
+  });
+
+  protected _onFilterChange(type: keyof Filters, selectedOptionValues: string[]) {
+    this._filtersValues.update((previousState) => ({
+      ...previousState,
+      [type]: selectedOptionValues,
+    }));
+  }
+
+  protected _onFiltersReset() {
+    this._filtersValues.set({
+      achievements: [],
+      status: [],
+    });
+  }
+
+  private _computeFilterOptions(options: SelectOption[]) {
+    return options.map(({ text, value }) => ({
+      text: this._t(marker(text as AppTranslationKey)),
+      value,
+    }));
   }
 }

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.types.ts
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.types.ts
@@ -1,0 +1,6 @@
+interface Filters {
+  achievements: string[];
+  status: string[];
+}
+
+export type { Filters };

--- a/packages/frontend/src/features/quiz/ui/topic-card-list/components/topic-card/topic-card.component.scss
+++ b/packages/frontend/src/features/quiz/ui/topic-card-list/components/topic-card/topic-card.component.scss
@@ -24,6 +24,7 @@
     grid-row: 1 / 2;
     flex-wrap: wrap;
     gap: var(--spacing-x2);
+    justify-content: end;
   }
 
   &__badge {

--- a/packages/frontend/src/shared/ui/index.ts
+++ b/packages/frontend/src/shared/ui/index.ts
@@ -11,5 +11,6 @@ export { LogoComponent } from './logo/logo.component';
 export { ModalComponent } from './modal/modal.component';
 export { PopoverComponent } from './popover';
 export { ProgressComponent } from './progress';
+export { SelectComponent, type SelectOption } from './select';
 export { SpinComponent } from './spin';
 export { TeamBoardComponent } from './team-board';

--- a/packages/frontend/src/shared/ui/select/index.ts
+++ b/packages/frontend/src/shared/ui/select/index.ts
@@ -1,0 +1,2 @@
+export { SelectComponent } from './select.component';
+export type { Option as SelectOption } from './select.types';

--- a/packages/frontend/src/shared/ui/select/select.component.html
+++ b/packages/frontend/src/shared/ui/select/select.component.html
@@ -1,0 +1,54 @@
+@let labelValue = label();
+@let placeholderValue = computedPlaceholder();
+@let optionList = options();
+@let expanded = isOpen();
+
+<div class="select">
+  @if (labelValue) {
+    <span [id]="_labelId" class="select__label">{{ labelValue }}</span>
+  }
+
+  <div class="select__wrapper" [class.select__wrapper_expanded]="expanded">
+    <div
+      class="select__input-wrapper"
+      role="combobox"
+      [aria-labelledby]="labelValue ? _labelId : undefined"
+      [aria-controls]="_listboxId"
+      aria-haspopup="listbox"
+      [aria-expanded]="expanded"
+      tabindex="0"
+      (keydown)="_onKeydown($event)"
+      (click)="_onClick()"
+    >
+      @if (placeholderValue) {
+        <div class="select__input-placeholder">{{ placeholderValue }}</div>
+      }
+
+      <app-icon class="select__icon" name="arrow-up" />
+    </div>
+
+    <ul
+      [id]="_listboxId"
+      class="select__dropdown"
+      role="listbox"
+      [aria-labelledby]="labelValue ? _labelId : undefined"
+      tabindex="-1"
+    >
+      @for (option of optionList; track option.value) {
+        <li class="select__option-list-item">
+          <label class="select__option-item">
+            <input
+              class="select__option-input"
+              type="checkbox"
+              [value]="option.value"
+              [checked]="_isOptionSelected()(option.value)"
+              (change)="_onOptionChange($event)"
+            />
+
+            <span class="select__option-label">{{ option.text }}</span>
+          </label>
+        </li>
+      }
+    </ul>
+  </div>
+</div>

--- a/packages/frontend/src/shared/ui/select/select.component.scss
+++ b/packages/frontend/src/shared/ui/select/select.component.scss
@@ -1,0 +1,149 @@
+@use 'assets/styles/placeholders';
+@use 'assets/styles/mixins' as mix;
+
+:host {
+  width: 100%;
+}
+
+.select {
+  $this: &;
+
+  display: flex;
+  flex-direction: column;
+
+  &__wrapper {
+    position: relative;
+    margin-block-start: var(--spacing-x2);
+
+    &_expanded {
+      #{$this}__icon {
+        transform: rotate(270deg);
+      }
+
+      #{$this}__dropdown {
+        @extend %visible;
+        transform: translateY(0);
+      }
+    }
+  }
+
+  &__input-wrapper {
+    cursor: pointer;
+    user-select: none;
+
+    position: relative;
+    z-index: 2;
+
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-x3);
+    align-items: center;
+
+    min-height: 52px;
+    padding: var(--spacing-x2) var(--spacing-x12) var(--spacing-x2) var(--spacing-x3);
+    border: 1px solid var(--secondary-color);
+    border-radius: var(--radius-md);
+
+    background-color: var(--primary-color);
+
+    &:focus-visible {
+      border-radius: var(--radius-sm);
+      outline: var(--button-border);
+      outline-offset: 2px;
+    }
+  }
+
+  &__input-placeholder {
+    @extend %text-inline-hidden;
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: var(--spacing-x3);
+    transform: translateY(-50%);
+
+    max-width: calc(100% - var(--spacing-x12));
+
+    color: rgb(var(--secondary-color-rgb), 0.66);
+  }
+
+  &__icon {
+    position: absolute;
+    inset-block-start: calc(var(--spacing-x7) / 2);
+    inset-inline-end: var(--spacing-x3);
+    transform: rotate(90deg);
+    @include mix.transition(transform);
+  }
+
+  &__dropdown {
+    @extend %hidden;
+    position: absolute;
+    z-index: 3;
+    inset-inline-start: 0;
+    transform: translateY(var(--spacing-x4));
+
+    overflow-y: auto;
+
+    width: 100%;
+    max-height: 248px;
+    margin-block-start: var(--spacing-x2);
+    border-radius: var(--radius-md);
+
+    background-color: var(--primary-color);
+    box-shadow: 0 4px 26px 0 rgb(var(--secondary-color-rgb), 0.2);
+    @include mix.set-scrollbar(6);
+    @include mix.transition((opacity, visibility, transform));
+  }
+
+  &__option-list-item {
+    &:not(:last-child) {
+      border-block-end: 1px solid var(--secondary-color);
+    }
+
+    &:first-child {
+      #{$this}__option-item {
+        border-start-start-radius: var(--radius-md);
+        border-start-end-radius: var(--radius-md);
+      }
+    }
+
+    &:last-child {
+      #{$this}__option-item {
+        border-end-start-radius: var(--radius-md);
+        border-end-end-radius: var(--radius-md);
+      }
+    }
+  }
+
+  &__option-item {
+    cursor: pointer;
+    user-select: none;
+
+    position: relative;
+
+    display: flex;
+
+    padding: var(--spacing-x4) var(--spacing-x5) var(--spacing-x4) var(--spacing-x3);
+    @include mix.transition((color, background-color));
+
+    &:has(input:focus-visible) {
+      outline: var(--button-border);
+      outline-offset: -2px;
+    }
+
+    &:has(input:focus-visible:checked) {
+      outline-color: var(--secondary-color);
+    }
+
+    &:has(input:checked) {
+      color: var(--primary-color);
+      background-color: var(--accent-color);
+    }
+  }
+
+  &__option-input {
+    @extend %visually-hidden;
+  }
+
+  &__option-label {
+    overflow-wrap: anywhere;
+  }
+}

--- a/packages/frontend/src/shared/ui/select/select.component.spec.ts
+++ b/packages/frontend/src/shared/ui/select/select.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SelectComponent } from './select.component';
+
+describe('SelectComponent', () => {
+  let component: SelectComponent;
+  let fixture: ComponentFixture<SelectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SelectComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/shared/ui/select/select.component.ts
+++ b/packages/frontend/src/shared/ui/select/select.component.ts
@@ -1,0 +1,93 @@
+import { Component, ElementRef, computed, input, output, signal } from '@angular/core';
+
+import { IconComponent } from '@/shared/ui';
+
+import { computePlaceholder } from './select.utilities';
+
+import type { Option } from './select.types';
+
+@Component({
+  selector: 'app-select',
+  host: {
+    '(document:click)': '_onDocumentClick($event)',
+    '(document:keydown.escape)': '_onEscapePressed()',
+  },
+  imports: [IconComponent],
+  templateUrl: './select.component.html',
+  styleUrl: './select.component.scss',
+  standalone: true,
+})
+export class SelectComponent {
+  readonly label = input<string>();
+  readonly placeholder = input<string>();
+  readonly options = input<Option[]>([]);
+  readonly selectedOptionValues = input<Option['value'][]>([]);
+
+  readonly selectedOptionValuesChange = output<Option['value'][]>();
+
+  readonly isOpen = signal(false);
+
+  protected readonly _labelId = crypto.randomUUID();
+  protected readonly _listboxId = crypto.randomUUID();
+  protected _isOptionSelected = computed(
+    () => (value: Option['value']) => this.selectedOptionValues().includes(value),
+  );
+
+  private readonly _elementRef: ElementRef<HTMLDivElement>;
+
+  computedPlaceholder = computed(() =>
+    computePlaceholder(this.options(), this.selectedOptionValues(), this.placeholder()),
+  );
+
+  constructor(element: ElementRef<HTMLDivElement>) {
+    this._elementRef = element;
+  }
+
+  protected _onOptionChange(event: Event) {
+    if (!(event.target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    const selectedOptionValues = this.selectedOptionValues();
+    const { value, checked } = event.target;
+
+    const nextSelectedOptionValues = checked
+      ? [...selectedOptionValues, value]
+      : selectedOptionValues.filter((v) => v !== value);
+    this.selectedOptionValuesChange.emit(nextSelectedOptionValues);
+  }
+
+  protected _onClick() {
+    this._onOpenChange();
+  }
+
+  protected _onKeydown(event: KeyboardEvent) {
+    if (event.code !== 'Space') {
+      return;
+    }
+
+    event.preventDefault();
+    this._onOpenChange();
+  }
+
+  protected _onDocumentClick({ target }: MouseEvent) {
+    if (!(target instanceof HTMLElement || target instanceof SVGElement)) {
+      return;
+    }
+
+    const isClickedInside = this._elementRef.nativeElement.contains(target);
+    if (isClickedInside) {
+      return;
+    }
+
+    this.isOpen.set(false);
+  }
+
+  protected _onEscapePressed() {
+    this.isOpen.set(false);
+  }
+
+  private _onOpenChange() {
+    this.isOpen.update((previousState) => !previousState);
+  }
+}

--- a/packages/frontend/src/shared/ui/select/select.types.ts
+++ b/packages/frontend/src/shared/ui/select/select.types.ts
@@ -1,0 +1,6 @@
+interface Option {
+  text: string;
+  value: string;
+}
+
+export type { Option };

--- a/packages/frontend/src/shared/ui/select/select.utilities.ts
+++ b/packages/frontend/src/shared/ui/select/select.utilities.ts
@@ -1,0 +1,28 @@
+import type { Option } from './select.types';
+
+const findFirstSelectedOption = (options: Option[], selectedOptionValues: string[]) =>
+  options.find((option) => option.value === selectedOptionValues.at(0));
+
+const computePlaceholder = (
+  options: Option[],
+  selectedOptionValues: string[],
+  placeholder = '',
+) => {
+  const selectedCount = selectedOptionValues.length;
+
+  if (selectedCount <= 0) {
+    return placeholder;
+  }
+
+  const firstSelectedOption = findFirstSelectedOption(options, selectedOptionValues);
+
+  if (!firstSelectedOption) {
+    return `Selected: ${String(selectedCount)}`;
+  }
+
+  const restSelectedCount = selectedCount - 1;
+
+  return `${firstSelectedOption.text}${restSelectedCount > 0 ? ` +${String(restSelectedCount)}` : ''}`;
+};
+
+export { computePlaceholder };


### PR DESCRIPTION
### ⚡ **PR: Add reusable Select filters**

---

#### 📋 **Description**

- **What:** Added a reusable `Select` UI Kit component in multiselect mode, connected it to category filters on Challenges and Quiz pages, added localized filter options, empty filtered-state UI, and reset filters behavior.
- **Why:** This was necessary to make filtering reusable, predictable, and controlled from parent pages instead of storing selection state inside option objects.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2/views/1?pane=issue&itemId=166099784&issue=jsgods-rs-tandem%7Crs-tandem%7C148

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [x] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Open Challenges category page and Quiz category page.
2. Select several values in filters and verify that the topic lists react immediately.
3. Switch application language between `en` and `ru`.
4. Reset filters from the empty filtered-state if no items match.
5. **Expected result:** Multiselect filters work on both pages, selected values remain synced with UI, placeholders update correctly, translated option labels are recalculated on language change, and reset returns the full list.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**
<img width="1510" height="856" alt="Screenshot 2026-04-08 at 00 03 22" src="https://github.com/user-attachments/assets/6840badf-f6f5-4a09-aea2-16e9e8b6b1a7" />
<img width="1511" height="856" alt="Screenshot 2026-04-08 at 01 58 07" src="https://github.com/user-attachments/assets/72a68bd8-2a5b-4fc7-b7b8-28822840e578" />
<img width="1507" height="852" alt="Screenshot 2026-04-08 at 01 58 13" src="https://github.com/user-attachments/assets/adce6542-b77f-46b7-8386-ce77e90b3227" />
<img width="1510" height="856" alt="Screenshot 2026-04-08 at 01 58 20" src="https://github.com/user-attachments/assets/e74a1ce1-40ce-46cc-b8d0-395b00355a30" />
<img width="1508" height="858" alt="Screenshot 2026-04-08 at 01 58 44" src="https://github.com/user-attachments/assets/dc342c11-7385-458a-8562-389777411bfb" />
<img width="1512" height="858" alt="Screenshot 2026-04-08 at 01 59 02" src="https://github.com/user-attachments/assets/7adb36b9-c103-4a08-b115-cfe3fdaba622" />
<img width="1507" height="857" alt="Screenshot 2026-04-08 at 01 59 12" src="https://github.com/user-attachments/assets/67ee6879-d32e-4889-95c5-6ddfa3f3a4f1" />
<img width="1512" height="858" alt="Screenshot 2026-04-08 at 01 59 25" src="https://github.com/user-attachments/assets/1c10f2ac-20a4-4d93-8de8-99aa52012146" />
<img width="1510" height="859" alt="Screenshot 2026-04-08 at 01 59 37" src="https://github.com/user-attachments/assets/c1975ef9-1c8f-4d98-831c-0815817b412f" />
