### PR TITLE
feat: add confetti animation on quiz results page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7738,6 +7738,315 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tsparticles/angular": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tsparticles/angular/-/angular-3.0.0.tgz",
+      "integrity": "sha512-mnPN/U4/I6A5JHvZXQWq0/mzPDVxfCmNYrIXxQv4NVUnYQT2DzN4vkZuB0BPdurN077Yqey87p6HdcnPhnOZfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=2.0.0",
+        "@angular/core": ">=2.0.0",
+        "@tsparticles/engine": "^3.0.2",
+        "rxjs": ">=7.0.0"
+      }
+    },
+    "node_modules/@tsparticles/basic": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-3.9.1.tgz",
+      "integrity": "sha512-ijr2dHMx0IQHqhKW3qA8tfwrR2XYbbWYdaJMQuBo2CkwBVIhZ76U+H20Y492j/NXpd1FUnt2aC0l4CEVGVGdeQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1",
+        "@tsparticles/move-base": "3.9.1",
+        "@tsparticles/plugin-hex-color": "3.9.1",
+        "@tsparticles/plugin-hsl-color": "3.9.1",
+        "@tsparticles/plugin-rgb-color": "3.9.1",
+        "@tsparticles/shape-circle": "3.9.1",
+        "@tsparticles/updater-color": "3.9.1",
+        "@tsparticles/updater-opacity": "3.9.1",
+        "@tsparticles/updater-out-modes": "3.9.1",
+        "@tsparticles/updater-size": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/engine": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-3.9.1.tgz",
+      "integrity": "sha512-DpdgAhWMZ3Eh2gyxik8FXS6BKZ8vyea+Eu5BC4epsahqTGY9V3JGGJcXC6lRJx6cPMAx1A0FaQAojPF3v6rkmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsparticles/move-base": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/move-base/-/move-base-3.9.1.tgz",
+      "integrity": "sha512-X4huBS27d8srpxwOxliWPUt+NtCwY+8q/cx1DvQxyqmTA8VFCGpcHNwtqiN+9JicgzOvSuaORVqUgwlsc7h4pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-emitters": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-3.9.1.tgz",
+      "integrity": "sha512-h7opR8SoFWBmVHceDLJUerLENaPfkJSh2zQYvzmLj2L+V3VLS1QDgty+4QZVeZfqNROmgQw2eLFA5El1E0sqqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-hex-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-3.9.1.tgz",
+      "integrity": "sha512-vZgZ12AjUicJvk7AX4K2eAmKEQX/D1VEjEPFhyjbgI7A65eX72M465vVKIgNA6QArLZ1DLs7Z787LOE6GOBWsg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-hsl-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-3.9.1.tgz",
+      "integrity": "sha512-jJd1iGgRwX6eeNjc1zUXiJivaqC5UE+SC2A3/NtHwwoQrkfxGWmRHOsVyLnOBRcCPgBp/FpdDe6DIDjCMO715w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-motion": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-motion/-/plugin-motion-3.9.1.tgz",
+      "integrity": "sha512-I/356NHCiMUgFzWjAHYKO7YvBqKtHSktIPgTRruqlruyrAcwzjkT55ZQ1K5EcJLWETkF1bfG2VpJBRu8ksf9mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-rgb-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-3.9.1.tgz",
+      "integrity": "sha512-SBxk7f1KBfXeTnnklbE2Hx4jBgh6I6HOtxb+Os1gTp0oaghZOkWcCD2dP4QbUu7fVNCMOcApPoMNC8RTFcy9wQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/preset-confetti": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@tsparticles/preset-confetti/-/preset-confetti-3.2.0.tgz",
+      "integrity": "sha512-47T8vkV37K5ZKGYZOuLtTd4ONSpnuLQ+LbKnFoh3g4zrgqzknmKTuVEFQAXQFigWWjDnHbATEnnMOIZkz+xWXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/basic": "^3.7.1",
+        "@tsparticles/engine": "^3.7.1",
+        "@tsparticles/plugin-emitters": "^3.7.1",
+        "@tsparticles/plugin-motion": "^3.7.1",
+        "@tsparticles/shape-square": "^3.7.1",
+        "@tsparticles/updater-life": "^3.7.1",
+        "@tsparticles/updater-roll": "^3.7.1",
+        "@tsparticles/updater-rotate": "^3.7.1",
+        "@tsparticles/updater-tilt": "^3.7.1",
+        "@tsparticles/updater-wobble": "^3.7.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-circle": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-3.9.1.tgz",
+      "integrity": "sha512-DqZFLjbuhVn99WJ+A9ajz9YON72RtCcvubzq6qfjFmtwAK7frvQeb6iDTp6Ze9FUipluxVZWVRG4vWTxi2B+/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-square": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-3.9.1.tgz",
+      "integrity": "sha512-DKGkDnRyZrAm7T2ipqNezJahSWs6xd9O5LQLe5vjrYm1qGwrFxJiQaAdlb00UNrexz1/SA7bEoIg4XKaFa7qhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-color/-/updater-color-3.9.1.tgz",
+      "integrity": "sha512-XGWdscrgEMA8L5E7exsE0f8/2zHKIqnTrZymcyuFBw2DCB6BIV+5z6qaNStpxrhq3DbIxxhqqcybqeOo7+Alpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-life": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-3.9.1.tgz",
+      "integrity": "sha512-Oi8aF2RIwMMsjssUkCB6t3PRpENHjdZf6cX92WNfAuqXtQphr3OMAkYFJFWkvyPFK22AVy3p/cFt6KE5zXxwAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-opacity": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-3.9.1.tgz",
+      "integrity": "sha512-w778LQuRZJ+IoWzeRdrGykPYSSaTeWfBvLZ2XwYEkh/Ss961InOxZKIpcS6i5Kp/Zfw0fS1ZAuqeHwuj///Osw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-out-modes": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-3.9.1.tgz",
+      "integrity": "sha512-cKQEkAwbru+hhKF+GTsfbOvuBbx2DSB25CxOdhtW2wRvDBoCnngNdLw91rs+0Cex4tgEeibkebrIKFDDE6kELg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-roll": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-3.9.1.tgz",
+      "integrity": "sha512-zl4JeM3gUBJ0uttmIsond3lrZ3f3AkItFeS0Lhj/7jiCKfUoRyyOMrcBk8R1AhW7lI+7ko1iBs3jhO0jnxz9vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-rotate": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-3.9.1.tgz",
+      "integrity": "sha512-9BfKaGfp28JN82MF2qs6Ae/lJr9EColMfMTHqSKljblwbpVDHte4umuwKl3VjbRt87WD9MGtla66NTUYl+WxuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-size": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-3.9.1.tgz",
+      "integrity": "sha512-3NSVs0O2ApNKZXfd+y/zNhTXSFeG1Pw4peI8e6z/q5+XLbmue9oiEwoPy/tQLaark3oNj3JU7Q903ZijPyXSzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-tilt": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-3.9.1.tgz",
+      "integrity": "sha512-PB2yaoyXRmSk4iIVgjtRrzOxXMK9mjeAQHIJGtT4faq46Z8cbIIEFgjTwqrUV8qOrNg/h4sm5NE/s0qsTYjp1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-wobble": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-3.9.1.tgz",
+      "integrity": "sha512-c99Ogy9q4QWO+zsDXol0UnpUwZiY2UucFb8ltuDv9AlbGUeprygoub8jhgT5pEDv+GdzWOJGSgq7rfgv9cHBrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -22954,6 +23263,8 @@
         "@angular/platform-browser": "^21.1.0",
         "@angular/router": "^21.1.0",
         "@rs-tandem/shared": "*",
+        "@tsparticles/angular": "^3.0.0",
+        "@tsparticles/preset-confetti": "^3.2.0",
         "monaco-editor": "^0.55.1",
         "ngx-monaco-editor-v2": "^21.1.4",
         "prismjs": "^1.30.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,6 +22,8 @@
     "@angular/platform-browser": "^21.1.0",
     "@angular/router": "^21.1.0",
     "@rs-tandem/shared": "*",
+    "@tsparticles/angular": "^3.0.0",
+    "@tsparticles/preset-confetti": "^3.2.0",
     "monaco-editor": "^0.55.1",
     "ngx-monaco-editor-v2": "^21.1.4",
     "prismjs": "^1.30.0",

--- a/packages/frontend/src/features/quiz/pages/results-page/results-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/results-page/results-page.component.html
@@ -40,6 +40,8 @@
 
         <app-button link="..">{{ 'quiz.results.actions.reExploreTopic' | transloco }}</app-button>
       </div>
+
+      <ngx-particles [id]="_id" [options]="_particlesOptions" />
     </div>
   } @else {
     <app-empty

--- a/packages/frontend/src/features/quiz/pages/results-page/results-page.component.ts
+++ b/packages/frontend/src/features/quiz/pages/results-page/results-page.component.ts
@@ -1,5 +1,7 @@
 import { Component, computed, effect, inject, input, type OnInit } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
+import { NgxParticlesModule, NgParticlesService } from '@tsparticles/angular';
+import { loadConfettiPreset } from '@tsparticles/preset-confetti';
 
 import { LayoutComponent } from '@/pages/layout';
 import { ButtonComponent, EmptyComponent } from '@/shared/ui';
@@ -11,13 +13,21 @@ import { computeRewardLevel } from '../../utilities';
 import { TypedTranslocoPipe } from '@/shared/pipes/typed-transloco.pipe';
 
 import { ROUTE_PATHS } from '@/core/constants';
+import { particlesOptions } from './results-page.constants';
 import { REWARD_PRAISE } from '../../constants';
 
 import type { AppTranslationKey } from '@/shared/types/translation-keys';
 
 @Component({
   selector: 'app-results-page',
-  imports: [ButtonComponent, DecimalPipe, EmptyComponent, LayoutComponent, TypedTranslocoPipe],
+  imports: [
+    ButtonComponent,
+    DecimalPipe,
+    EmptyComponent,
+    LayoutComponent,
+    NgxParticlesModule,
+    TypedTranslocoPipe,
+  ],
   templateUrl: './results-page.component.html',
   styleUrl: './results-page.component.scss',
   standalone: true,
@@ -29,8 +39,17 @@ export class ResultsPageComponent implements OnInit {
   readonly topicId = input.required<string>();
 
   readonly ROUTE_PATHS = ROUTE_PATHS;
+  readonly headingKey = computed<AppTranslationKey>(
+    () => REWARD_PRAISE[computeRewardLevel(this.quizService.results()?.score ?? 0)],
+  );
 
-  constructor() {
+  protected readonly _id = 'tsparticles';
+  protected readonly _particlesOptions = particlesOptions;
+  protected readonly _ngParticlesService: NgParticlesService;
+
+  constructor(ngParticlesService: NgParticlesService) {
+    this._ngParticlesService = ngParticlesService;
+
     effect((onCleanup) => {
       onCleanup(() => {
         this.quizService.resetResults();
@@ -40,9 +59,9 @@ export class ResultsPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.quizService.getResults(this.topicId());
-  }
 
-  readonly headingKey = computed<AppTranslationKey>(
-    () => REWARD_PRAISE[computeRewardLevel(this.quizService.results()?.score ?? 0)],
-  );
+    void this._ngParticlesService.init(async (engine) => {
+      await loadConfettiPreset(engine);
+    });
+  }
 }

--- a/packages/frontend/src/features/quiz/pages/results-page/results-page.constants.ts
+++ b/packages/frontend/src/features/quiz/pages/results-page/results-page.constants.ts
@@ -1,0 +1,46 @@
+import type { NgxParticlesComponent } from '@tsparticles/angular';
+
+export const particlesOptions: NonNullable<NgxParticlesComponent['options']> = {
+  preset: 'confetti',
+  fpsLimit: 60,
+  detectRetina: true,
+  particles: {
+    color: {
+      value: ['#ff6900', '#ffd54f', '#cfd8dc', '#ffab91', '#f48fb1'],
+    },
+  },
+  emitters: [
+    {
+      life: {
+        duration: 0.24,
+        count: 0,
+      },
+      position: {},
+      rate: {
+        delay: 0.3,
+        quantity: 8,
+      },
+      particles: {
+        move: {
+          direction: 'top-right',
+        },
+      },
+    },
+    {
+      life: {
+        duration: 0.24,
+        count: 0,
+      },
+      position: {},
+      rate: {
+        delay: 0.3,
+        quantity: 8,
+      },
+      particles: {
+        move: {
+          direction: 'top-left',
+        },
+      },
+    },
+  ],
+} as const;


### PR DESCRIPTION
### ⚡ **PR: Add Confetti Animation To Quiz Results**

---

#### 📋 **Description**

- **What:** Added a celebratory confetti animation to the quiz results page using `tsParticles`, connected it in the results page template/component, and moved the particle configuration into `results-page.constants.ts`.
- **Why:** This improves the success-state UX on the results screen and keeps the animation setup isolated and easier to maintain and tune.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2?pane=issue&itemId=173455567&issue=jsgods-rs-tandem%7Crs-tandem%7C228

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [ ] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [x] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Open the frontend app and complete a quiz to reach the results page.
2. Verify that the confetti animation appears on the results screen and does not break the existing layout or buttons.
3. **Expected result:** The results page shows a celebratory confetti effect with the configured colors and burst directions, while the rest of the UI works as before.

---

#### ✅ **Pre-Flight Checklist**

- [ ] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**

<img width="1512" height="859" alt="Screenshot 2026-04-08 at 10 54 29" src="https://github.com/user-attachments/assets/85516027-1230-4583-94f5-545171ef69e0" />
