### PR TITLE
feat: add popover smooth transition

### DIFF
--- a/packages/frontend/src/shared/ui/popover/popover.component.scss
+++ b/packages/frontend/src/shared/ui/popover/popover.component.scss
@@ -1,3 +1,5 @@
+@use 'assets/styles/mixins' as mix;
+
 .popover {
   position: absolute;
   inset: auto;
@@ -7,10 +9,26 @@
 
   inline-size: max-content;
   max-inline-size: 300px;
+  margin-block-end: calc(-1 * var(--spacing-x1));
   padding: 0 0 10px;
   border: none;
 
+  opacity: 0;
   background: transparent;
+
+  transition-behavior: allow-discrete;
+
+  @include mix.transition((overlay, display, margin-block-end, opacity));
+
+  &:popover-open {
+    margin-block-end: 0;
+    opacity: 1;
+
+    @starting-style {
+      margin-block-end: calc(-1 * var(--spacing-x1));
+      opacity: 0;
+    }
+  }
 
   &__content {
     position: relative;


### PR DESCRIPTION
### ⚡ PR: Fix Popover Open/Close Animation

---

#### 📋 Description

- **What:** Updated popover styles so the animation works both on open and on close by separating closed/open states correctly and using `@starting-style` with `display`/`overlay` transitions.
- **Why:** For better UX
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2/views/1?pane=issue&itemId=173537831&issue=jsgods-rs-tandem%7Crs-tandem%7C232

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 Change Type

- [ ] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 How to Test

1. Open the UI element that triggers the popover.
2. Verify that the popover fades/slides in when opened.
3. Close the popover and verify that it fades/slides out instead of disappearing instantly.
4. **Expected result:** The popover animates smoothly in both directions.

---

#### ✅ Pre-Flight Checklist

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 Screenshots / GIFs

N/A