### PR TITLE
fix: make smooth popover animation in reverse side

### DIFF
--- a/packages/frontend/src/shared/ui/popover/popover.component.scss
+++ b/packages/frontend/src/shared/ui/popover/popover.component.scss
@@ -1,5 +1,3 @@
-@use 'assets/styles/mixins' as mix;
-
 .popover {
   position: absolute;
   inset: auto;
@@ -16,9 +14,12 @@
   opacity: 0;
   background: transparent;
 
-  transition-behavior: allow-discrete;
-
-  @include mix.transition((overlay, display, margin-block-end, opacity));
+  // We list proprties explicitly (not via a mixin), because auto-formatting breaks the smooth reverse animation
+  transition:
+    margin-block-end var(--transition-duration-basic) var(--transition-easing-func),
+    opacity var(--transition-duration-basic) var(--transition-easing-func),
+    display var(--transition-duration-basic) allow-discrete,
+    overlay var(--transition-duration-basic) allow-discrete;
 
   &:popover-open {
     margin-block-end: 0;


### PR DESCRIPTION
### ⚡ PR: Fix Reverse Popover Transition

---

#### 📋 Description

- **What:** Updated the popover transition declaration to explicitly list `margin-block-end`, `opacity`, `display`, and `overlay` instead of using a mixin.
- **Why:** This preserves smooth animation behavior in both directions, because the previous formatting/mixin-based output was breaking the reverse popover animation.
- **Related Issue:** N/A

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 Change Type

- [x] `fix` [Bug correction]
- [ ] `feat` [New functionality]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 How to Test

1. Open a UI element that shows the popover.
2. Verify the popover animates smoothly when opening.
3. Close the popover and verify the reverse animation is also smooth.
4. **Expected result:** The popover transition works correctly in both directions without abrupt closing behavior.

---

#### ✅ Pre-Flight Checklist

- [x] Style guides followed.
- [x] No console.logs
- [ ] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 Screenshots / GIFs

N/A