### PR TITLE
feat: update select to handle single state and intergrate it with ai settings

### DIFF
--- a/packages/frontend/public/i18n/en.json
+++ b/packages/frontend/public/i18n/en.json
@@ -580,6 +580,7 @@
       "title": "AI",
       "useRemoteProvider": "Use remote provider?",
       "provider": "Provider",
+      "providerPlaceholder": "Select provider",
       "model": "Model",
       "apiKey": "API key",
       "update": "Update Settings",

--- a/packages/frontend/public/i18n/ru.json
+++ b/packages/frontend/public/i18n/ru.json
@@ -582,6 +582,7 @@
       "title": "ИИ",
       "useRemoteProvider": "Использовать удаленный провайдер?",
       "provider": "Провайдер",
+      "providerPlaceholder": "Выберите провайдер",
       "model": "Модель",
       "apiKey": "API ключ",
       "update": "Обновить настройки",

--- a/packages/frontend/src/features/ai-settings/ai-settings.component.html
+++ b/packages/frontend/src/features/ai-settings/ai-settings.component.html
@@ -16,23 +16,31 @@
     </div>
 
     <div class="provider-wrapper" [ngClass]="settings().useRemoteProvider ? 'enabled' : 'disabled'">
-      <h3 class="h3">{{ 'settings.ai.provider' | transloco }}</h3>
-      <select name="provider" id="model" class="select" formControlName="provider">
-        @for (provider of providers(); track provider) {
-          <option value="{{ provider.id }}">
-            {{ provider.label }}
-          </option>
-        }
-      </select>
-      <h3 class="h3">{{ 'settings.ai.model' | transloco }}</h3>
-      <app-input [placeholder]="'Model'" formControlName="model" [targetType]="'text'"></app-input>
-      <h3 class="h3">{{ 'settings.ai.apiKey' | transloco }}</h3>
-      <app-input
-        [placeholder]="'settings.ai.apiKey' | transloco"
-        class="input"
-        formControlName="apiKey"
-        [targetType]="'password'"
-      ></app-input>
+      <app-select
+        [label]="'settings.ai.provider' | transloco"
+        [placeholder]="'settings.ai.providerPlaceholder' | transloco"
+        [options]="providerOptions()"
+        [selectedOptionValues]="selectedProvider()"
+        (selectedOptionValuesChange)="onProviderChange($event)"
+      />
+      <div class="model-wrapper">
+        <h3 class="text-base settings-label">{{ 'settings.ai.model' | transloco }}</h3>
+        <app-input
+          [placeholder]="'Model'"
+          formControlName="model"
+          [targetType]="'text'"
+        ></app-input>
+      </div>
+
+      <div>
+        <h3 class="text-base settings-label">{{ 'settings.ai.apiKey' | transloco }}</h3>
+        <app-input
+          [placeholder]="'settings.ai.apiKey' | transloco"
+          class="input"
+          formControlName="apiKey"
+          [targetType]="'password'"
+        ></app-input>
+      </div>
     </div>
 
     <div class="control-wrapper">

--- a/packages/frontend/src/features/ai-settings/ai-settings.component.scss
+++ b/packages/frontend/src/features/ai-settings/ai-settings.component.scss
@@ -29,35 +29,17 @@
 }
 
 .select {
-  cursor: pointer;
-
-  width: 100%;
-  min-height: 52px;
   margin-top: var(--spacing-x2);
-  padding: var(--spacing-x2) var(--spacing-x3);
-  border: 1px solid var(--secondary-color);
-  border-top-left-radius: var(--radius-md);
-  border-top-right-radius: var(--radius-md);
-
-  font-family: var(--font-main);
-  font-size: fn.to-rem(16px);
-  line-height: 1.5;
-  color: var(--text-primary);
-
-  background-color: transparent;
-  outline: none;
-  @include m.transition((border-color, box-shadow));
-
-  option {
-    color: var(--secondary-color);
-    background-color: var(--primary-color);
-  }
 }
 
 .disabled {
   pointer-events: none;
   user-select: none;
   opacity: 0.3;
+}
+
+.model-wrapper {
+  margin-top: var(--spacing-x5);
 }
 
 .control-wrapper {
@@ -69,4 +51,8 @@
     flex-direction: column;
     gap: var(--spacing-x2);
   }
+}
+
+.settings-label {
+  font-weight: var(--fw-regular);
 }

--- a/packages/frontend/src/features/ai-settings/ai-settings.component.ts
+++ b/packages/frontend/src/features/ai-settings/ai-settings.component.ts
@@ -2,8 +2,8 @@ import { SwitcherComponent } from '@/shared/switcher/switcher.component';
 import { InputComponent } from '@/shared/ui/input/input.component';
 import { LineBreakComponent } from '@/shared/ui/line-break/line-break.component';
 import { NgClass } from '@angular/common';
-import { Component, inject, signal } from '@angular/core';
-import { ButtonComponent, SpinComponent } from '@/shared/ui';
+import { Component, computed, inject, signal } from '@angular/core';
+import { ButtonComponent, SelectComponent, SpinComponent } from '@/shared/ui';
 import { AiHttpService } from '../ai-chat/services/ai-http-service';
 import { ModalService } from '@/core/services/modal.service';
 import { AiSettingsHttpService } from './ai-settings-http.service';
@@ -38,6 +38,7 @@ const initialProviders: AiProviderDto[] = [
     InputComponent,
     NgClass,
     ButtonComponent,
+    SelectComponent,
     SpinComponent,
     ReactiveFormsModule,
     TranslocoPipe,
@@ -49,6 +50,7 @@ export class AiSettingsComponent {
   protected providers = signal<AiProviderDto[]>(initialProviders);
   protected isLoading = signal(true);
   protected settings = signal<ISettings>(initialSettings);
+  protected selectedProvider = signal<string[]>([]);
   protected settingsForm = new FormGroup({
     provider: new FormControl(''),
     model: new FormControl(''),
@@ -63,6 +65,15 @@ export class AiSettingsComponent {
   constructor() {
     this.loadProviders();
     this.loadSettings();
+  }
+
+  protected providerOptions = computed(() =>
+    this.providers().map(({ id, label }) => ({ text: label, value: id })),
+  );
+
+  protected onProviderChange(values: string[]) {
+    this.selectedProvider.set(values);
+    this.settingsForm.controls.provider.setValue(values[0] ?? '');
   }
 
   protected handleSubmit() {
@@ -143,6 +154,7 @@ export class AiSettingsComponent {
           model: settings.model ?? '',
           apiKey: settings.apiKey ?? '',
         });
+        this.selectedProvider.set(this.getSelectedProviderValues(settings.providerId));
       },
       error: (error: unknown) => {
         console.error('Error fetching AI settings:', error);
@@ -171,6 +183,12 @@ export class AiSettingsComponent {
 
   toggleProvider(event: boolean) {
     this.settings.update((current) => ({ ...current, useRemoteProvider: event }));
+
+    if (event) {
+      this.selectedProvider.set(
+        this.getSelectedProviderValues(this.settingsForm.controls.provider.value),
+      );
+    }
   }
 
   protected resetChatHistory() {
@@ -215,5 +233,9 @@ export class AiSettingsComponent {
       message: `${this.t('settings.ai.modal.validationError.startOfMessage')} "${field}" ${this.t('settings.ai.modal.validationError.endOfMessage')}`,
       buttonText: 'OK',
     });
+  }
+
+  private getSelectedProviderValues(provider: string | null) {
+    return provider && provider !== 'ollama' ? [provider] : [];
   }
 }

--- a/packages/frontend/src/features/challenges/pages/category-page/category-page.component.html
+++ b/packages/frontend/src/features/challenges/pages/category-page/category-page.component.html
@@ -23,6 +23,7 @@
           [placeholder]="'challenges.category.filters.difficulty.placeholder' | transloco"
           [options]="_difficultyFilter()"
           [selectedOptionValues]="filters.difficulty"
+          [multiple]="true"
           (selectedOptionValuesChange)="_onFilterChange('difficulty', $event)"
         />
 
@@ -31,6 +32,7 @@
           [placeholder]="'challenges.category.filters.tags.placeholder' | transloco"
           [options]="_tagsFilter()"
           [selectedOptionValues]="filters.tags"
+          [multiple]="true"
           (selectedOptionValuesChange)="_onFilterChange('tags', $event)"
         />
 
@@ -40,6 +42,7 @@
           [placeholder]="'challenges.category.filters.status.placeholder' | transloco"
           [options]="_statusFilter()"
           [selectedOptionValues]="filters.status"
+          [multiple]="true"
           (selectedOptionValuesChange)="_onFilterChange('status', $event)"
         />
       </div>

--- a/packages/frontend/src/features/quiz/pages/category-page/category-page.component.html
+++ b/packages/frontend/src/features/quiz/pages/category-page/category-page.component.html
@@ -23,6 +23,7 @@
           [placeholder]="'quiz.category.filters.achievements.placeholder' | transloco"
           [options]="_achievementsFilter()"
           [selectedOptionValues]="filters.achievements"
+          [multiple]="true"
           (selectedOptionValuesChange)="_onFilterChange('achievements', $event)"
         />
 
@@ -31,6 +32,7 @@
           [placeholder]="'quiz.category.filters.status.placeholder' | transloco"
           [options]="_statusFilter()"
           [selectedOptionValues]="filters.status"
+          [multiple]="true"
           (selectedOptionValuesChange)="_onFilterChange('status', $event)"
         />
       </div>

--- a/packages/frontend/src/shared/ui/select/select.component.html
+++ b/packages/frontend/src/shared/ui/select/select.component.html
@@ -5,7 +5,7 @@
 
 <div class="select">
   @if (labelValue) {
-    <span [id]="_labelId" class="select__label">{{ labelValue }}</span>
+    <span [id]="_labelId">{{ labelValue }}</span>
   }
 
   <div class="select__wrapper" [class.select__wrapper_expanded]="expanded">

--- a/packages/frontend/src/shared/ui/select/select.component.ts
+++ b/packages/frontend/src/shared/ui/select/select.component.ts
@@ -22,6 +22,7 @@ export class SelectComponent {
   readonly placeholder = input<string>();
   readonly options = input<Option[]>([]);
   readonly selectedOptionValues = input<Option['value'][]>([]);
+  readonly multiple = input<boolean>(false);
 
   readonly selectedOptionValuesChange = output<Option['value'][]>();
 
@@ -43,18 +44,16 @@ export class SelectComponent {
     this._elementRef = element;
   }
 
-  protected _onOptionChange(event: Event) {
-    if (!(event.target instanceof HTMLInputElement)) {
+  protected _onOptionChange({ target }: Event) {
+    if (!(target instanceof HTMLInputElement)) {
       return;
     }
 
-    const selectedOptionValues = this.selectedOptionValues();
-    const { value, checked } = event.target;
-
-    const nextSelectedOptionValues = checked
-      ? [...selectedOptionValues, value]
-      : selectedOptionValues.filter((v) => v !== value);
-    this.selectedOptionValuesChange.emit(nextSelectedOptionValues);
+    if (this.multiple()) {
+      this._onMultipleOptionChange(target);
+    } else {
+      this._onSingleOptionChange(target);
+    }
   }
 
   protected _onClick() {
@@ -89,5 +88,21 @@ export class SelectComponent {
 
   private _onOpenChange() {
     this.isOpen.update((previousState) => !previousState);
+  }
+
+  private _onSingleOptionChange({ value }: HTMLInputElement) {
+    this.selectedOptionValuesChange.emit(
+      this.selectedOptionValues().includes(value) ? [] : [value],
+    );
+    this.isOpen.set(false);
+  }
+
+  private _onMultipleOptionChange({ value, checked }: HTMLInputElement) {
+    const selectedOptionValues = this.selectedOptionValues();
+    const nextSelectedOptionValues = checked
+      ? [...selectedOptionValues, value]
+      : selectedOptionValues.filter((v) => v !== value);
+
+    this.selectedOptionValuesChange.emit(nextSelectedOptionValues);
   }
 }


### PR DESCRIPTION
### ⚡ **PR: Add single-select support and integrate it into AI settings**

---

#### 📋 **Description**

- **What:** Added single-value mode to `app-select`, updated existing filter usages to explicitly stay in multi-select mode, and replaced the provider native select in `ai-settings` with `app-select` plus state sync for selected provider.
- **Why:** This was necessary to reuse the shared select component in `ai-settings` while preserving the existing multi-select behavior in other screens and handling the `ollama` local-provider edge case.
- **Related Issue:** https://github.com/orgs/jsgods-rs-tandem/projects/2?pane=issue&itemId=174267740&issue=jsgods-rs-tandem%7Crs-tandem%7C244

---

## 📦 Affected Packages

- [x] `@rs-tandem/frontend`
- [ ] `@rs-tandem/backend`
- [ ] `@rs-tandem/shared`

---

#### 🎭 **Change Type**

- [x] `feat` [New functionality]
- [x] `fix` [Bug correction]
- [ ] `refactor` [Code changes without logic shifts]
- [ ] `chore` [Updates to dependencies, configs]
- [ ] `docs` [Documentation updates]

---

#### 🧪 **How to Test**

1. Open AI settings and verify the provider field is rendered with `app-select` instead of the native select.
2. Toggle `Use remote provider` on, choose a provider, then toggle it off and on again.
3. **Expected result:** The select placeholder updates to the selected provider, the previous remote selection is preserved across toggle changes, and multi-select filters in challenges/quiz still allow selecting multiple values.

---

#### ✅ **Pre-Flight Checklist**

- [x] Style guides followed.
- [x] No console.logs
- [x] No commented code
- [x] No `any` / `@ts-ignore`
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if needed).

---

#### 📸 **Screenshots / GIFs**

<img width="1512" height="860" alt="Screenshot 2026-04-10 at 13 22 26" src="https://github.com/user-attachments/assets/77e672c6-f2c8-4532-95cb-2cbf9c7dd7bc" />
<img width="1512" height="859" alt="Screenshot 2026-04-10 at 13 22 33" src="https://github.com/user-attachments/assets/e2bbdf36-0ceb-4305-a3ec-b27fd1c3c3ae" />
<img width="1512" height="858" alt="Screenshot 2026-04-10 at 13 22 40" src="https://github.com/user-attachments/assets/384b84df-8114-4be6-b5a8-0ddf2009534e" />
